### PR TITLE
Depreciation Resolution and More PEP 8

### DIFF
--- a/modules/sfp_accounts.py
+++ b/modules/sfp_accounts.py
@@ -85,8 +85,7 @@ class sfp_accounts(SpiderFootPlugin):
                                    )
 
             if res['content'] is None:
-                self.sf.debug("Unable to check the status of account " + name \
-                              + " on " + site)
+                self.sf.debug("Unable to check the status of account " + name + " on " + site)
             else:
                 if "Sorry," in res['content']:
                     ret.append(site)

--- a/modules/sfp_adblock.py
+++ b/modules/sfp_adblock.py
@@ -72,8 +72,7 @@ class sfp_adblock(SpiderFootPlugin):
                     self.errorState = True
                     self.sf.error("Parsing error handling AdBlock list: " + str(e), False)
             else:
-                self.sf.error("Unable to download AdBlockPlus list: " + \
-                              self.opts['blocklist'])
+                self.sf.error("Unable to download AdBlockPlus list: " + self.opts['blocklist'])
 
         if "_EXTERNAL" in eventName:
             pagetype = "_EXTERNAL"

--- a/modules/sfp_blacklist.py
+++ b/modules/sfp_blacklist.py
@@ -157,21 +157,21 @@ class sfp_blacklist(SpiderFootPlugin):
 
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
-        if self.results.has_key(eventData):
+        if eventData in self.results:
             return None
         self.results[eventData] = True
 
         if eventName == 'NETBLOCK_OWNER' and self.opts['netblocklookup']:
             if IPNetwork(eventData).prefixlen < self.opts['maxnetblock']:
-                self.sf.debug("Network size bigger than permitted: " + \
-                              str(IPNetwork(eventData).prefixlen) + " > " + \
+                self.sf.debug("Network size bigger than permitted: " +
+                              str(IPNetwork(eventData).prefixlen) + " > " +
                               str(self.opts['maxnetblock']))
                 return None
 
         if eventName == 'NETBLOCK_MEMBER' and self.opts['subnetlookup']:
             if IPNetwork(eventData).prefixlen < self.opts['maxsubnet']:
-                self.sf.debug("Network size bigger than permitted: " + \
-                              str(IPNetwork(eventData).prefixlen) + " > " + \
+                self.sf.debug("Network size bigger than permitted: " +
+                              str(IPNetwork(eventData).prefixlen) + " > " +
                               str(self.opts['maxsubnet']))
                 return None
 

--- a/modules/sfp_cookie.py
+++ b/modules/sfp_cookie.py
@@ -47,7 +47,7 @@ class sfp_cookie(SpiderFootPlugin):
         eventSource = event.sourceEvent.data
 
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
-        if self.results.has_key(eventSource):
+        if eventSource in self.results:
             return None
         else:
             self.results[eventSource] = True
@@ -56,7 +56,7 @@ class sfp_cookie(SpiderFootPlugin):
             self.sf.debug("Not collecting cookies from external sites.")
             return None
 
-        if eventData.has_key('set-cookie'):
+        if 'set-cookie' in eventData:
             evt = SpiderFootEvent("TARGET_WEB_COOKIE", eventData['set-cookie'],
                                   self.__name__, parentEvent)
             self.notifyListeners(evt)

--- a/modules/sfp_dns.py
+++ b/modules/sfp_dns.py
@@ -145,7 +145,7 @@ class sfp_dns(SpiderFootPlugin):
 
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
-        if self.events.has_key(eventData):
+        if eventData in self.events:
             return None
 
         self.events[eventData] = True
@@ -167,8 +167,8 @@ class sfp_dns(SpiderFootPlugin):
 
         if eventName == 'NETBLOCK_OWNER' and self.opts['netblocklookup']:
             if IPNetwork(eventData).prefixlen < self.opts['maxnetblock']:
-                self.sf.debug("Network size bigger than permitted: " + \
-                              str(IPNetwork(eventData).prefixlen) + " > " + \
+                self.sf.debug("Network size bigger than permitted: " +
+                              str(IPNetwork(eventData).prefixlen) + " > " +
                               str(self.opts['maxnetblock']))
                 return None
 
@@ -185,7 +185,7 @@ class sfp_dns(SpiderFootPlugin):
                 addrs = self.resolveIP(ipaddr)
 
                 if len(addrs) > 0:
-                    self.sf.debug("Found a reversed hostname from " + ipaddr + \
+                    self.sf.debug("Found a reversed hostname from " + ipaddr +
                                   " (" + str(addrs) + ")")
                     for addr in addrs:
                         # Generate an event for the IP, then
@@ -224,7 +224,7 @@ class sfp_dns(SpiderFootPlugin):
                     if self.checkForStop():
                         return None
 
-                    if self.hostresults.has_key(sip):
+                    if sip in self.hostresults:
                         s += 1
                         continue
 
@@ -254,8 +254,8 @@ class sfp_dns(SpiderFootPlugin):
         ret = list()
         self.sf.debug("Performing reverse-resolve of " + ipaddr)
 
-        if self.resolveCache.has_key(ipaddr):
-            self.sf.debug("Returning cached result for " + ipaddr + " (" + \
+        if ipaddr in self.resolveCache:
+            self.sf.debug("Returning cached result for " + ipaddr + " (" +
                           str(self.resolveCache[ipaddr]) + ")")
             return self.resolveCache[ipaddr]
 
@@ -271,8 +271,8 @@ class sfp_dns(SpiderFootPlugin):
 
     # Resolve a host
     def resolveHost(self, hostname):
-        if self.resolveCache.has_key(hostname):
-            self.sf.debug("Returning cached result for " + hostname + " (" + \
+        if hostname in self.resolveCache:
+            self.sf.debug("Returning cached result for " + hostname + " (" +
                           str(self.resolveCache[hostname]) + ")")
             return self.resolveCache[hostname]
 
@@ -287,8 +287,8 @@ class sfp_dns(SpiderFootPlugin):
 
     # Resolve a host to IPv6
     def resolveHost6(self, hostname):
-        if self.resolveCache6.has_key(hostname):
-            self.sf.debug("Returning IPv6 cached result for " + hostname + " (" + \
+        if hostname in self.resolveCache6:
+            self.sf.debug("Returning IPv6 cached result for " + hostname + " (" +
                           str(self.resolveCache6[hostname]) + ")")
             return self.resolveCache6[hostname]
 
@@ -309,7 +309,7 @@ class sfp_dns(SpiderFootPlugin):
 
     # Process a host/IP, parentEvent is the event that represents this entity
     def processHost(self, host, parentEvent, affiliate=None):
-        if not self.hostresults.has_key(host):
+        if host not in self.hostresults:
             self.hostresults[host] = list(parentEvent.data)
         else:
             if parentEvent.data in self.hostresults[host] or parentEvent.data == host:
@@ -365,7 +365,7 @@ class sfp_dns(SpiderFootPlugin):
         return evt
 
     def processDomain(self, domainName, parentEvent):
-        if not self.domresults.has_key(domainName):
+        if domainName not in self.domresults:
             self.domresults[domainName] = True
         else:
             self.sf.debug("Skipping domain, " + domainName + ", already processed.")
@@ -416,7 +416,7 @@ class sfp_dns(SpiderFootPlugin):
                                                   self.__name__, domevt)
                             self.notifyListeners(evt)
             except BaseException as e:
-                self.sf.error("Failed to obtain DNS response for " + domainName + \
+                self.sf.error("Failed to obtain DNS response for " + domainName +
                               "(" + rec + "): " + str(e), False)
 
         self.sf.debug("Iterating through possible sub-domains [" + str(self.sublist) + "]")

--- a/modules/sfp_filemeta.py
+++ b/modules/sfp_filemeta.py
@@ -76,12 +76,12 @@ class sfp_filemeta(SpiderFootPlugin):
                 ret = self.sf.fetchUrl(eventData, timeout=self.opts['timeout'],
                                        useragent=self.opts['_useragent'], dontMangle=True)
                 if ret['content'] is None:
-                    self.sf.error("Unable to fetch file for meta analysis: " + \
+                    self.sf.error("Unable to fetch file for meta analysis: " +
                                   eventData, False)
                     return None
 
                 if len(ret['content']) < 512:
-                    self.sf.error("Strange content encountered, size of " + \
+                    self.sf.error("Strange content encountered, size of " +
                                   str(len(ret['content'])), False)
 
                 meta = None
@@ -94,7 +94,7 @@ class sfp_filemeta(SpiderFootPlugin):
                         meta = str(data)
                         self.sf.debug("Obtained meta data from " + eventData)
                     except BaseException as e:
-                        self.sf.error("Unable to parse meta data from: " + \
+                        self.sf.error("Unable to parse meta data from: " +
                                       eventData + "(" + str(e) + ")", False)
 
                 if fileExt.lower() in ["pptx", "docx", "xlsx"]:
@@ -105,13 +105,13 @@ class sfp_filemeta(SpiderFootPlugin):
                         data = doc.allProperties
                         meta = str(data)
                     except ValueError as e:
-                        self.sf.error("Unable to parse meta data from: " + \
+                        self.sf.error("Unable to parse meta data from: " +
                                       eventData + "(" + str(e) + ")", False)
                     except lxml.etree.XMLSyntaxError as e:
-                        self.sf.error("Unable to parse XML within: " + \
+                        self.sf.error("Unable to parse XML within: " +
                                       eventData + "(" + str(e) + ")", False)
                     except BaseException as e:
-                        self.sf.error("Unable to process file: " + \
+                        self.sf.error("Unable to process file: " +
                                       eventData + "(" + str(e) + ")", False)
 
                 if fileExt.lower() in ["jpg", "jpeg", "tiff"]:
@@ -122,7 +122,7 @@ class sfp_filemeta(SpiderFootPlugin):
                             return None
                         meta = str(data)
                     except BaseException as e:
-                        self.sf.error("Unable to parse meta data from: " + \
+                        self.sf.error("Unable to parse meta data from: " +
                                       eventData + "(" + str(e) + ")", False)
 
                 if meta is not None:
@@ -131,17 +131,17 @@ class sfp_filemeta(SpiderFootPlugin):
                     self.notifyListeners(evt)
 
                     val = None
-                    if data.has_key("/Producer"):
+                    if "/Producer" in data:
                         val = data['/Producer']
 
-                    if data.has_key("/Creator"):
+                    if "/Creator" in data:
                         if data['/Creator'] != data['/Producer']:
                             val = data['/Creator']
 
-                    if data.has_key("Application"):
+                    if "Application" in data:
                         val = data['Application']
 
-                    if data.has_key("Image Software"):
+                    if "Image Software" in data:
                         val = str(data['Image Software'])
 
                     if val is not None:

--- a/modules/sfp_geoip.py
+++ b/modules/sfp_geoip.py
@@ -48,7 +48,7 @@ class sfp_geoip(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         # Don't look up stuff twice
-        if self.results.has_key(eventData):
+        if eventData in self.results:
             self.sf.debug("Skipping " + eventData + " as already mapped.")
             return None
         else:

--- a/modules/sfp_honeypot.py
+++ b/modules/sfp_honeypot.py
@@ -151,21 +151,21 @@ class sfp_honeypot(SpiderFootPlugin):
             self.sf.error("You enabled sfp_honeypot but did not set an API key!", False)
             return None
 
-        if self.results.has_key(eventData):
+        if eventData in self.results:
             return None
         self.results[eventData] = True
 
         if eventName == 'NETBLOCK_OWNER' and self.opts['netblocklookup']:
             if IPNetwork(eventData).prefixlen < self.opts['maxnetblock']:
-                self.sf.debug("Network size bigger than permitted: " + \
-                              str(IPNetwork(eventData).prefixlen) + " > " + \
+                self.sf.debug("Network size bigger than permitted: " +
+                              str(IPNetwork(eventData).prefixlen) + " > " +
                               str(self.opts['maxnetblock']))
                 return None
 
         if eventName == 'NETBLOCK_MEMBER' and self.opts['subnetlookup']:
             if IPNetwork(eventData).prefixlen < self.opts['maxsubnet']:
-                self.sf.debug("Network size bigger than permitted: " + \
-                              str(IPNetwork(eventData).prefixlen) + " > " + \
+                self.sf.debug("Network size bigger than permitted: " +
+                              str(IPNetwork(eventData).prefixlen) + " > " +
                               str(self.opts['maxsubnet']))
                 return None
 

--- a/modules/sfp_intfiles.py
+++ b/modules/sfp_intfiles.py
@@ -90,25 +90,25 @@ class sfp_intfiles(SpiderFootPlugin):
         for fileExt in self.opts['fileexts']:
             # Sites hosted on the domain
             if self.opts['searchengine'].lower() == "google":
-                pages = self.sf.googleIterate("site:" + eventData + "+" + \
+                pages = self.sf.googleIterate("site:" + eventData + "+" +
                                               "%2Bext:" + fileExt, dict(limit=self.opts['pages'],
                                                                         useragent=self.opts['_useragent'],
                                                                         timeout=self.opts['_fetchtimeout']))
 
             if self.opts['searchengine'].lower() == "bing":
-                pages = self.sf.bingIterate("site:" + eventData + "+" + \
+                pages = self.sf.bingIterate("site:" + eventData + "+" +
                                             "%2Bext:" + fileExt, dict(limit=self.opts['pages'],
                                                                       useragent=self.opts['_useragent'],
                                                                       timeout=self.opts['_fetchtimeout']))
 
             if self.opts['searchengine'].lower() == "yahoo":
-                pages = self.sf.yahooIterate("site:" + eventData + "+" + \
+                pages = self.sf.yahooIterate("site:" + eventData + "+" +
                                              "%2Bext:" + fileExt, dict(limit=self.opts['pages'],
                                                                        useragent=self.opts['_useragent'],
                                                                        timeout=self.opts['_fetchtimeout']))
 
             if pages is None:
-                self.sf.info("No results returned from " + self.opts['searchengine'] + \
+                self.sf.info("No results returned from " + self.opts['searchengine'] +
                              " for " + fileExt + " files.")
                 continue
 

--- a/modules/sfp_ir.py
+++ b/modules/sfp_ir.py
@@ -52,7 +52,7 @@ class sfp_ir(SpiderFootPlugin):
 
     # Fetch content and notify of the raw data
     def fetchRir(self, url):
-        if self.memCache.has_key(url):
+        if url in self.memCache:
             res = self.memCache[url]
         else:
             res = self.sf.fetchUrl(url, timeout=self.opts['_fetchtimeout'],
@@ -135,7 +135,7 @@ class sfp_ir(SpiderFootPlugin):
                         d["key"].lower().startswith("aut") or \
                                 d["key"].lower().startswith("descr") and \
                                         d["value"].lower() not in ["null", "none", "none specified"]:
-                    if ownerinfo.has_key(d["key"]):
+                    if d["key"] in ownerinfo:
                         ownerinfo[d["key"]].append(d["value"])
                     else:
                         ownerinfo[d["key"]] = [d["value"]]
@@ -245,7 +245,7 @@ class sfp_ir(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         # Don't look up stuff twice
-        if self.results.has_key(eventData):
+        if eventData in self.results:
             self.sf.debug("Skipping " + eventData + " as already mapped.")
             return None
         else:
@@ -277,13 +277,13 @@ class sfp_ir(SpiderFootPlugin):
         if eventName == "BGP_AS_OWNER":
             # Don't report additional netblocks from this AS if we've
             # already found this AS before.
-            if not self.nbreported.has_key(eventData):
+            if eventData not in self.nbreported:
                 # Find all the netblocks owned by this AS
                 self.nbreported[eventData] = True
                 netblocks = self.asNetblocks(eventData)
                 if netblocks is not None:
                     for netblock in netblocks:
-                        if self.results.has_key(netblock):
+                        if netblock in self.results:
                             continue
 
                         # Technically this netblock was identified via the AS, not

--- a/modules/sfp_malcheck.py
+++ b/modules/sfp_malcheck.py
@@ -365,8 +365,8 @@ class sfp_malcheck(SpiderFootPlugin):
                     # Get the regex, replace {0} with an IP address matcher to 
                     # build a list of IP.
                     # Cycle through each IP and check if it's in the netblock.
-                    if malchecks[check].has_key('regex'):
-                        rx = malchecks[check]['regex'].replace("{0}", \
+                    if 'regex' in malchecks[check]:
+                        rx = malchecks[check]['regex'].replace("{0}",
                                                                "(\d+\.\d+\.\d+\.\d+)")
                         pat = re.compile(rx, re.IGNORECASE)
                         self.sf.debug("New regex for " + check + ": " + rx)
@@ -385,7 +385,7 @@ class sfp_malcheck(SpiderFootPlugin):
 
                         try:
                             if IPAddress(ip) in IPNetwork(target):
-                                self.sf.debug(ip + " found within netblock/subnet " + \
+                                self.sf.debug(ip + " found within netblock/subnet " +
                                               target + " in " + check)
                                 return url
                         except Exception as e:
@@ -395,7 +395,7 @@ class sfp_malcheck(SpiderFootPlugin):
                     return None
 
                 # If we're looking at hostnames/domains/IPs
-                if not malchecks[check].has_key('regex'):
+                if 'regex' not in malchecks[check]:
                     for line in data['content'].split('\n'):
                         if line == target or (targetType == "domain" and line == targetDom):
                             self.sf.debug(target + "/" + targetDom + " found in " + check + " list.")
@@ -415,7 +415,7 @@ class sfp_malcheck(SpiderFootPlugin):
         for check in malchecks.keys():
             cid = malchecks[check]['id']
             if cid == resourceId and itemType in malchecks[check]['checks']:
-                self.sf.debug("Checking maliciousness of " + target + " (" + \
+                self.sf.debug("Checking maliciousness of " + target + " (" +
                               itemType + ") with: " + cid)
                 if malchecks[check]['type'] == "query":
                     return self.resourceQuery(cid, target, itemType)

--- a/modules/sfp_pastebin.py
+++ b/modules/sfp_pastebin.py
@@ -109,7 +109,7 @@ class sfp_pastebin(SpiderFootPlugin):
                     self.notifyListeners(evt)
 
                     # Sometimes pastebin search results false positives
-                    if re.search("[^a-zA-Z\-\_0-9]" + re.escape(eventData) + \
+                    if re.search("[^a-zA-Z\-\_0-9]" + re.escape(eventData) +
                                          "[^a-zA-Z\-\_0-9]", res['content'], re.IGNORECASE) is None:
                         continue
 

--- a/modules/sfp_portscan_tcp.py
+++ b/modules/sfp_portscan_tcp.py
@@ -164,13 +164,13 @@ class sfp_portscan_tcp(SpiderFootPlugin):
             else:
                 scanIps.append(eventData)
         except BaseException as e:
-            self.sf.error("Strange netblock identified, unable to parse: " + \
+            self.sf.error("Strange netblock identified, unable to parse: " +
                           eventData + " (" + str(e) + ")", False)
             return None
 
         for ipAddr in scanIps:
             # Don't look up stuff twice
-            if self.results.has_key(ipAddr):
+            if ipAddr in self.results:
                 self.sf.debug("Skipping " + ipAddr + " as already scanned.")
                 return None
             else:

--- a/modules/sfp_shodan.py
+++ b/modules/sfp_shodan.py
@@ -54,7 +54,7 @@ class sfp_shodan(SpiderFootPlugin):
                 "TCP_PORT_OPEN", "TCP_PORT_OPEN_BANNER"]
 
     def query(self, qry):
-        res = self.sf.fetchUrl("https://api.shodan.io/shodan/host/" + qry + \
+        res = self.sf.fetchUrl("https://api.shodan.io/shodan/host/" + qry +
                                "?key=" + self.opts['apikey'],
                                timeout=self.opts['_fetchtimeout'], useragent="SpiderFoot")
         if res['content'] is None:
@@ -82,7 +82,7 @@ class sfp_shodan(SpiderFootPlugin):
             return None
 
             # Don't look up stuff twice
-        if self.results.has_key(eventData):
+        if eventData in self.results:
             self.sf.debug("Skipping " + eventData + " as already mapped.")
             return None
         else:
@@ -90,8 +90,8 @@ class sfp_shodan(SpiderFootPlugin):
 
         if eventName == 'NETBLOCK_OWNER' and self.opts['netblocklookup']:
             if IPNetwork(eventData).prefixlen < self.opts['maxnetblock']:
-                self.sf.debug("Network size bigger than permitted: " + \
-                              str(IPNetwork(eventData).prefixlen) + " > " + \
+                self.sf.debug("Network size bigger than permitted: " +
+                              str(IPNetwork(eventData).prefixlen) + " > " +
                               str(self.opts['maxnetblock']))
                 return None
 
@@ -113,17 +113,17 @@ class sfp_shodan(SpiderFootPlugin):
 
             if rec.get('os') is not None:
                 # Notify other modules of what you've found
-                evt = SpiderFootEvent("OPERATING_SYSTEM", rec.get('os') + \
+                evt = SpiderFootEvent("OPERATING_SYSTEM", rec.get('os') +
                                       " (" + addr + ")", self.__name__, event)
                 self.notifyListeners(evt)
 
             if rec.get('devtype') is not None:
                 # Notify other modules of what you've found
-                evt = SpiderFootEvent("DEVICE_TYPE", rec.get('devtype') + \
+                evt = SpiderFootEvent("DEVICE_TYPE", rec.get('devtype') +
                                       " (" + addr + ")", self.__name__, event)
                 self.notifyListeners(evt)
 
-            if rec.has_key('data'):
+            if 'data' in rec:
                 self.sf.info("Found SHODAN data for " + eventData)
                 for r in rec['data']:
                     port = str(r.get('port'))

--- a/modules/sfp_similar.py
+++ b/modules/sfp_similar.py
@@ -112,7 +112,7 @@ class sfp_similar(SpiderFootPlugin):
 
                 self.storeResult(sourceEvent, result)
 
-            if not whoisLastPageIndicator in whois['content']:
+            if whoisLastPageIndicator not in whois['content']:
                 reachedEnd = True
             else:
                 time.sleep(random.randint(1, 10))
@@ -147,7 +147,7 @@ class sfp_similar(SpiderFootPlugin):
 
                 self.storeResult(sourceEvent, result)
 
-            if not domtoolLastPageIndicator in domtool['content']:
+            if domtoolLastPageIndicator not in domtool['content']:
                 reachedEnd = True
             else:
                 time.sleep(random.randint(1, 10))
@@ -179,7 +179,7 @@ class sfp_similar(SpiderFootPlugin):
 
                 self.storeResult(sourceEvent, result)
 
-            if not namedropLastPageIndicator in namedrop['content']:
+            if namedropLastPageIndicator not in namedrop['content']:
                 reachedEnd = True
             else:
                 time.sleep(random.randint(1, 10))

--- a/modules/sfp_social.py
+++ b/modules/sfp_social.py
@@ -78,7 +78,7 @@ class sfp_social(SpiderFootPlugin):
                 bits = re.match(regex, eventData, re.IGNORECASE)
                 if bits is not None:
                     self.sf.info("Matched " + regexpGrp + " in " + eventData)
-                    evt = SpiderFootEvent("SOCIAL_MEDIA", regexpGrp + ": " + \
+                    evt = SpiderFootEvent("SOCIAL_MEDIA", regexpGrp + ": " +
                                           bits.group(1), self.__name__, event)
                     self.notifyListeners(evt)
 

--- a/modules/sfp_socialprofiles.py
+++ b/modules/sfp_socialprofiles.py
@@ -152,8 +152,7 @@ class sfp_socialprofiles(SpiderFootPlugin):
                             else:
                                 found = False
                                 for kw in self.keywords:
-                                    if re.search("[^a-zA-Z\-\_]" + kw + \
-                                                         "[^a-zA-Z\-\_]", pres['content'], re.IGNORECASE):
+                                    if re.search("[^a-zA-Z\-\_]" + kw + "[^a-zA-Z\-\_]", pres['content'], re.IGNORECASE):
                                         found = True
                                 if not found:
                                     continue

--- a/modules/sfp_spider.py
+++ b/modules/sfp_spider.py
@@ -77,7 +77,7 @@ class sfp_spider(SpiderFootPlugin):
     def processUrl(self, url):
         site = self.sf.urlFQDN(url)
         cookies = None
-        if self.siteCookies.has_key(site):
+        if site in self.siteCookies:
             self.sf.debug("Restoring cookies for " + site + ": " + str(self.siteCookies[site]))
             cookies = self.siteCookies[site]
         # Fetch the contents of the supplied URL (object returned)
@@ -91,7 +91,7 @@ class sfp_spider(SpiderFootPlugin):
                 self.siteCookies[site] = fetched['headers'].get('Set-Cookie')
                 self.sf.debug("Saving cookies for " + site + ": " + str(self.siteCookies[site]))
 
-        if not self.urlEvents.has_key(url):
+        if url not in self.urlEvents:
             self.urlEvents[url] = None
 
         # Notify modules about the content obtained
@@ -262,7 +262,7 @@ class sfp_spider(SpiderFootPlugin):
         targetBase = self.sf.urlBaseUrl(startingPoint)
 
         # Are we respecting robots.txt?
-        if self.opts['robotsonly'] and not self.robotsRules.has_key(targetBase):
+        if self.opts['robotsonly'] and targetBase not in self.robotsRules:
             robotsTxt = self.sf.fetchUrl(targetBase + '/robots.txt',
                                          timeout=self.opts['_fetchtimeout'], useragent=self.opts['_useragent'])
             if robotsTxt['content'] is not None:
@@ -307,7 +307,7 @@ class sfp_spider(SpiderFootPlugin):
 
                     totalFetched += 1
                     if totalFetched >= self.opts['maxpages']:
-                        self.sf.info("Maximum number of pages (" + str(self.opts['maxpages']) + \
+                        self.sf.info("Maximum number of pages (" + str(self.opts['maxpages']) +
                                      ") reached.")
                         keepSpidering = False
                         break
@@ -319,7 +319,7 @@ class sfp_spider(SpiderFootPlugin):
             levelsTraversed += 1
             self.sf.info("Now at traversal level: " + str(levelsTraversed))
             if levelsTraversed >= self.opts['maxlevels']:
-                self.sf.info("Maximum number of levels (" + str(self.opts['maxlevels']) + \
+                self.sf.info("Maximum number of levels (" + str(self.opts['maxlevels']) +
                              ") reached.")
                 keepSpidering = False
 

--- a/modules/sfp_sslcert.py
+++ b/modules/sfp_sslcert.py
@@ -76,7 +76,7 @@ class sfp_sslcert(SpiderFootPlugin):
         else:
             fqdn = eventData
 
-        if not self.results.has_key(fqdn):
+        if fqdn not in self.results:
             self.results[fqdn] = True
         else:
             return None

--- a/modules/sfp_strangeheaders.py
+++ b/modules/sfp_strangeheaders.py
@@ -58,7 +58,7 @@ class sfp_strangeheaders(SpiderFootPlugin):
         eventSource = event.sourceEvent.data
 
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
-        if self.results.has_key(eventSource):
+        if eventSource in self.results:
             return None
         else:
             self.results[eventSource] = True

--- a/modules/sfp_virustotal.py
+++ b/modules/sfp_virustotal.py
@@ -110,8 +110,8 @@ class sfp_virustotal(SpiderFootPlugin):
             self.sf.error("You enabled sfp_virustotal but did not set an API key!", False)
             return None
 
-       # Don't look up stuff twice
-        if self.results.has_key(eventData):
+        # Don't look up stuff twice
+        if eventData in self.results:
             self.sf.debug("Skipping " + eventData + " as already mapped.")
             return None
         else:
@@ -125,15 +125,15 @@ class sfp_virustotal(SpiderFootPlugin):
 
         if eventName == 'NETBLOCK_OWNER' and self.opts['netblocklookup']:
             if IPNetwork(eventData).prefixlen < self.opts['maxnetblock']:
-                self.sf.debug("Network size bigger than permitted: " + \
-                              str(IPNetwork(eventData).prefixlen) + " > " + \
+                self.sf.debug("Network size bigger than permitted: " +
+                              str(IPNetwork(eventData).prefixlen) + " > " +
                               str(self.opts['maxnetblock']))
                 return None
 
         if eventName == 'NETBLOCK_MEMBER' and self.opts['subnetlookup']:
             if IPNetwork(eventData).prefixlen < self.opts['maxsubnet']:
-                self.sf.debug("Network size bigger than permitted: " + \
-                              str(IPNetwork(eventData).prefixlen) + " > " + \
+                self.sf.debug("Network size bigger than permitted: " +
+                              str(IPNetwork(eventData).prefixlen) + " > " +
                               str(self.opts['maxsubnet']))
                 return None
 
@@ -152,7 +152,7 @@ class sfp_virustotal(SpiderFootPlugin):
             info = self.query(addr)
             if info is None:
                 continue
-            if info.has_key('detected_urls'):
+            if 'detected_urls' in info:
                 self.sf.info("Found VirusTotal URL data for " + addr)
                 if eventName in ["IP_ADDRESS"] or eventName.startswith("NETBLOCK_"):
                     evt = "MALICIOUS_IPADDR"
@@ -178,7 +178,7 @@ class sfp_virustotal(SpiderFootPlugin):
                           addr + "/information/</SFURL>"
 
                 # Notify other modules of what you've found
-                e = SpiderFootEvent(evt, "VirusTotal [" + addr + "]\n" + \
+                e = SpiderFootEvent(evt, "VirusTotal [" + addr + "]\n" +
                                     infourl, self.__name__, event)
                 self.notifyListeners(e)
 

--- a/modules/sfp_websvr.py
+++ b/modules/sfp_websvr.py
@@ -48,7 +48,7 @@ class sfp_websvr(SpiderFootPlugin):
         eventSource = event.sourceEvent.data
 
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
-        if self.results.has_key(eventSource):
+        if eventSource in self.results:
             return None
         else:
             self.results[eventSource] = True
@@ -61,30 +61,30 @@ class sfp_websvr(SpiderFootPlugin):
         # banners and therefore classifying them further (type and version,
         # possibly OS. This could also trigger additional tests, such as 404s
         # and other errors to see what the header looks like.
-        if eventData.has_key('server'):
+        if 'server' in eventData:
             evt = SpiderFootEvent("WEBSERVER_BANNER", eventData['server'],
                                   self.__name__, parentEvent)
             self.notifyListeners(evt)
 
             self.sf.info("Found web server: " + eventData['server'] + " (" + eventSource + ")")
 
-        if eventData.has_key('x-powered-by'):
+        if 'x-powered-by' in eventData:
             evt = SpiderFootEvent("WEBSERVER_TECHNOLOGY", eventData['x-powered-by'],
                                   self.__name__, parentEvent)
             self.notifyListeners(evt)
             return None
 
         tech = None
-        if eventData.has_key('set-cookie') and 'PHPSESS' in eventData['set-cookie']:
+        if 'set-cookie'in eventData and 'PHPSESS' in eventData['set-cookie']:
             tech = "PHP"
 
-        if eventData.has_key('set-cookie') and 'JSESSIONID' in eventData['set-cookie']:
+        if 'set-cookie' in eventData and 'JSESSIONID' in eventData['set-cookie']:
             tech = "Java/JSP"
 
-        if eventData.has_key('set-cookie') and 'ASP.NET' in eventData['set-cookie']:
+        if 'set-cookie' in eventData and 'ASP.NET' in eventData['set-cookie']:
             tech = "ASP.NET"
 
-        if eventData.has_key('x-aspnet-version'):
+        if 'x-aspnet-version' in eventData:
             tech = "ASP.NET"
 
         if tech is not None and '.jsp' in eventSource:

--- a/sflib.py
+++ b/sflib.py
@@ -244,7 +244,7 @@ class SpiderFoot:
             if type(opts[opt]) is list:
                 storeopts[opt] = ','.join(opts[opt])
 
-        if not opts.has_key('__modules__'):
+        if '__modules__' not in opts:
             return storeopts
 
         for mod in opts['__modules__']:
@@ -279,7 +279,7 @@ class SpiderFoot:
             if opt.startswith('__') and filterSystem:
                 # Leave out system variables
                 continue
-            if opts.has_key(opt):
+            if opt in opts:
                 if type(referencePoint[opt]) is bool:
                     if opts[opt] == "1":
                         returnOpts[opt] = True
@@ -300,7 +300,7 @@ class SpiderFoot:
                     else:
                         returnOpts[opt] = str(opts[opt]).split(",")
 
-        if not referencePoint.has_key('__modules__'):
+        if '__modules__' not in referencePoint:
             return returnOpts
 
         # Module options
@@ -309,7 +309,7 @@ class SpiderFoot:
             for opt in referencePoint['__modules__'][modName]['opts']:
                 if opt.startswith('_') and filterSystem:
                     continue
-                if opts.has_key(modName + ":" + opt):
+                if modName + ":" + opt in opts:
                     if type(referencePoint['__modules__'][modName]['opts'][opt]) is bool:
                         if opts[modName + ":" + opt] == "1":
                             returnOpts['__modules__'][modName]['opts'][opt] = True
@@ -782,7 +782,7 @@ class SpiderFoot:
         fetches = 0
         returnResults = dict()
 
-        if opts.has_key('limit'):
+        if 'limit' in opts:
             limit = opts['limit']
 
         # We attempt to make the URL look as authentically human as possible
@@ -821,7 +821,7 @@ class SpiderFoot:
             self.info("Next Google URL: " + nextUrl)
 
             # Wait for a random number of seconds between fetches
-            if not opts.has_key('nopause'):
+            if 'nopause' not in opts:
                 pauseSecs = random.randint(4, 15)
                 self.info("Pausing for " + str(pauseSecs))
                 time.sleep(pauseSecs)
@@ -859,7 +859,7 @@ class SpiderFoot:
         fetches = 0
         returnResults = dict()
 
-        if opts.has_key('limit'):
+        if 'limit' in opts:
             limit = opts['limit']
 
         # We attempt to make the URL look as authentically human as possible
@@ -896,7 +896,7 @@ class SpiderFoot:
             self.info("Next Bing URL: " + nextUrl)
 
             # Wait for a random number of seconds between fetches
-            if not opts.has_key('nopause'):
+            if 'nopause' not in opts:
                 pauseSecs = random.randint(4, 15)
                 self.info("Pausing for " + str(pauseSecs))
                 time.sleep(pauseSecs)
@@ -934,7 +934,7 @@ class SpiderFoot:
         fetches = 0
         returnResults = dict()
 
-        if opts.has_key('limit'):
+        if 'limit' in opts:
             limit = opts['limit']
 
         # We attempt to make the URL look as authentically human as possible
@@ -968,7 +968,7 @@ class SpiderFoot:
             self.info("Next Yahoo URL: " + nextUrl)
 
             # Wait for a random number of seconds between fetches
-            if not opts.has_key('nopause'):
+            if 'nopause' not in opts:
                 pauseSecs = random.randint(4, 15)
                 self.info("Pausing for " + str(pauseSecs))
                 time.sleep(pauseSecs)
@@ -1329,14 +1329,14 @@ class SpiderFootEvent(object):
 # Override the default redirectors to re-use cookies
 class SmartRedirectHandler(urllib2.HTTPRedirectHandler):
     def http_error_301(self, req, fp, code, msg, headers):
-        if headers.has_key("Set-Cookie"):
+        if "Set-Cookie" in headers:
             req.add_header('cookie', headers['Set-Cookie'])
         result = urllib2.HTTPRedirectHandler.http_error_301(
             self, req, fp, code, msg, headers)
         return result
 
     def http_error_302(self, req, fp, code, msg, headers):
-        if headers.has_key("Set-Cookie"):
+        if "Set-Cookie" in headers:
             req.add_header('cookie', headers['Set-Cookie'])
         result = urllib2.HTTPRedirectHandler.http_error_302(
             self, req, fp, code, msg, headers)
@@ -1462,7 +1462,7 @@ class SpiderFootScanStatus:
 
     def getStatus(self, scanId):
         with self.lock:
-            if self.statusTable.has_key(scanId):
+            if scanId in self.statusTable:
                 return self.statusTable[scanId]
             return None
 

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -151,10 +151,10 @@ class SpiderFootWebUi:
                 ret['configdesc'][key] = self.config['__globaloptdescs__'][key]
             else:
                 [modName, modOpt] = key.split(':')
-                if not modName in self.config['__modules__'].keys():
+                if modName not in self.config['__modules__'].keys():
                     continue
 
-                if not modOpt in self.config['__modules__'][modName]['optdescs'].keys():
+                if modOpt not in self.config['__modules__'][modName]['optdescs'].keys():
                     continue
 
                 ret['configdesc'][key] = self.config['__modules__'][modName]['optdescs'][modOpt]
@@ -507,7 +507,7 @@ class SpiderFootWebUi:
             childId = row[8]
             datamap[childId] = row
 
-            if pc.has_key(parentId):
+            if parentId in pc:
                 if childId not in pc[parentId]:
                     pc[parentId].append(childId)
             else:
@@ -528,7 +528,7 @@ class SpiderFootWebUi:
                 datamap[childId] = row
                 #print childId + " = " + str(row)
 
-                if pc.has_key(parentId):
+                if parentId in pc:
                     if childId not in pc[parentId]:
                         pc[parentId].append(childId)
                 else:


### PR DESCRIPTION
This accomplishes three things:
* More PEP 8 Compliant.
* Removed redundant backslashes within brackets.
* Replaced all depreciated 'has_key()' instances with 'in'.

--------

'has_key()' has been depreciated in Python 2 and removed in Python 3. Additionally there is a performance gain by using 'in'.

To put this in perspective:
```
$ python2 -mtimeit -s'd=dict.fromkeys(range(99))' '12 in d'
10000000 loops, best of 3: 0.0339 usec per loop
$ python2 -mtimeit -s'd=dict.fromkeys(range(99))' 'd.has_key(12)'
10000000 loops, best of 3: 0.116 usec per loop
```

Due to the quantity of 'has_key()' instances that were replaced, this may provide a serious performance increase, or at least some sort of performance increase.

--------

References:
https://docs.python.org/2/library/stdtypes.html#dict.has_key