### PR TITLE
Re-added the RIPE module and the change to sfdb.py also added SSL support and Digest Authentication

### DIFF
--- a/modules/sfp_ripe.py
+++ b/modules/sfp_ripe.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+# -------------------------------------------------------------------------------
+# Name:         sfp_ripe
+# Purpose:      Query the RIPE REST API to find the person who registered the IP address
+#
+# Author:      Nander Hokwerda <nander@hackershub.co>
+#
+# Created:     7/11/2015
+# Copyright:   (c) Nander Hokwerda
+# Licence:     GPL
+# -------------------------------------------------------------------------------
+
+import json
+import sys
+import urllib2
+from sflib import SpiderFoot, SpiderFootPlugin, SpiderFootEvent
+
+
+class sfp_ripe(SpiderFootPlugin):
+    """RIPE Person Scan:Scan for person names:Get the person who registered the IP addresses"""
+
+    # Default options
+    opts = {
+        "restapiurl": "http://rest.db.ripe.net/search?query-string="
+    }
+
+    # Option descriptions
+    optdescs = {
+        "restapiurl": "The url for the RIPE REST API"
+    }
+
+    results = dict()
+
+
+    def setup(self, sfc, userOpts=dict()):
+        self.sf = sfc
+        self.results = dict()
+
+        # Clear / reset any other class member variables here
+        # or you risk them persisting between threads.
+
+        for opt in userOpts.keys():
+            self.opts[opt] = userOpts[opt]
+
+    # What events is this module interested in for input
+    def watchedEvents(self):
+        return ["IP_ADDRESS", "AFFILIATE_IPADDR"]
+
+    # What events this module produces
+    def producedEvents(self):
+        return ["HUMAN_NAME", "PHONENR", "GEOINFO"]
+
+    def query(self, qry):
+        try:
+            self.sf.info("[+] Starting query for: " + qry)
+
+            #Build the url based on the option and query address
+            restUrl = self.opts['restapiurl']
+            fullUrl = restUrl + qry
+
+            #Create a new request for the url and add the header so json is returned
+            req = urllib2.Request(fullUrl)
+            req.add_header('accept','application/json')
+
+            #Open the url and parse content as json
+            resp = urllib2.urlopen(req)
+            content = resp.read()
+            jsonContent = json.loads(content)
+
+            #init the variables
+            personName = None
+            phoneNr = None
+            physicalLocation = None
+
+            #Loop through the returned objects
+            for object in jsonContent['objects']['object']:
+                #If there is an object with type person look for attribute person and return its value
+                if object['type'] == "person":
+                    for attribute in object['attributes']['attribute']:
+                        if attribute['name'] == "person":
+                            personName = attribute['value']
+                        if attribute['name'] == "phone":
+                            phoneNr = attribute['value']
+                        if attribute['name'] == "address":
+                            if physicalLocation == None:
+                                physicalLocation = attribute['value']
+                            else:
+                                physicalLocation += " " + attribute['value']
+
+            #return the variables
+            return personName, phoneNr, physicalLocation
+
+        except Exception, e:
+            self.sf.info("[+] Caught error while executing query for: " + qry + " - " + str(e))
+            return None
+
+
+    # Handle events sent to this module
+    def handleEvent(self, event):
+        eventName = event.eventType
+        srcModuleName = event.module
+        eventData = event.data
+
+        self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
+
+            # Don't look up stuff twice
+        if eventData in self.results:
+            self.sf.debug("Skipping " + eventData + " as already mapped.")
+            return None
+        else:
+            self.results[eventData] = True
+
+        qrylist = list()
+
+        qrylist.append(eventData)
+
+        for addr in qrylist:
+            personName, phoneNr, physicalLocation = self.query(addr)
+            if personName is None and phoneNr is None:
+                continue
+
+            if self.checkForStop():
+                return None
+
+            if personName is not None:
+                # Notify other modules of what you've found
+                self.sf.info("Found RIPE Owner for " + eventData)
+                evt = SpiderFootEvent("HUMAN_NAME", personName , self.__name__, event)
+                self.notifyListeners(evt)
+
+            if phoneNr is not None:
+                # Notify other modules of what you've found
+                self.sf.info("Found phone number for RIPE Owner for " + eventData)
+                evt = SpiderFootEvent("PHONENR", phoneNr , self.__name__, event)
+                self.notifyListeners(evt)
+
+            if physicalLocation is not None:
+                # Notify other modules of what you've found
+                self.sf.info("Found address for RIPE Owner for " + eventData)
+                evt = SpiderFootEvent("GEOINFO", physicalLocation , self.__name__, event)
+                self.notifyListeners(evt)
+
+
+
+        return None
+
+# End of sfp_ripe class

--- a/secrets
+++ b/secrets
@@ -1,0 +1,3 @@
+{"users":[
+    {"username":"admin", "password":"admin"}
+]}

--- a/sfdb.py
+++ b/sfdb.py
@@ -192,7 +192,8 @@ class SpiderFootDb:
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('WEBSERVER_BANNER', 'Web Server', 0, 'DATA')",
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('WEBSERVER_HTTPHEADERS', 'HTTP Headers', 1, 'DATA')",
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('WEBSERVER_STRANGEHEADER', 'Non-Standard HTTP Header', 0, 'DATA')",
-        "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('WEBSERVER_TECHNOLOGY', 'Web Technology', 0, 'DESCRIPTOR')"
+        "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('WEBSERVER_TECHNOLOGY', 'Web Technology', 0, 'DESCRIPTOR')",
+        "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('PHONENR', 'Physical Phone Number', 0, 'ENTITY')"
     ]
 
     def __init__(self, opts):
@@ -657,7 +658,7 @@ class SpiderFootDb:
     # List of all previously run scans
     def scanInstanceList(self):
         # SQLite doesn't support OUTER JOINs, so we need a work-around that
-        # does a UNION of scans with results and scans without results to 
+        # does a UNION of scans with results and scans without results to
         # get a complete listing.
         qry = "SELECT i.guid, i.name, i.seed_target, ROUND(i.created/1000), \
             ROUND(i.started)/1000 as started, ROUND(i.ended)/1000, i.status, COUNT(r.type) \
@@ -738,7 +739,7 @@ class SpiderFootDb:
         except sqlite3.Error as e:
             self.sf.error("SQL error encountered when getting child element IDs: " + e.args[0])
 
-    # Get the full set of upstream IDs which are parents to the 
+    # Get the full set of upstream IDs which are parents to the
     # supplied set of IDs.
     # Data has to be in the format of output from scanElementSourcesDirect
     # and produce output in the same format.
@@ -791,7 +792,7 @@ class SpiderFootDb:
         datamap[parentId] = row
         return [datamap, pc]
 
-    # Get the full set of downstream IDs which are children of the 
+    # Get the full set of downstream IDs which are children of the
     # supplied set of IDs
     # NOTE FOR NOW THE BEHAVIOR IS NOT THE SAME AS THE scanElementParent*
     # FUNCTIONS - THIS ONLY RETURNS IDS!!


### PR DESCRIPTION
Re-added the RIPE module, it scans RIPE using the REST API together with any IP addresses found to get personal data on the person who reserved the IP address. It is dependent on the change to sfdb.py, this adds a new entity: PHONENR.
Changes to the sf.py file:
- Added SSL support, by default it checks whether there is a cert and key file with the name spiderfoot present. If not it'll create a new self signed 2048 bit sha256 certificate. If you got your own certificate you can comment out line 214 and update lines 215-216 for the path to your certificate. This does add a new prerequisite: python-openssl.
- Added Digest Authentication, it's the best that was available within cherrypy. It reads the secrets file in the spiderfoot directory for the users, so change this because now it is admin admin. It it fails to read the secrets file it'll fallback to a default admin admin login.
