### PR TITLE
Fix broken URL on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN rm -rf /var/lib/apt/lists/* \
 RUN addgroup spiderfoot && \
     useradd -r -g spiderfoot -d /home/spiderfoot -s /sbin/nologin -c "SpiderFoot User" spiderfoot
 
-ENV SPIDERFOOT_VERSION 2.7.0
+ENV SPIDERFOOT_VERSION 2.6.1
 
 # Download the specified release.
 WORKDIR /home


### PR DESCRIPTION
https://github.com/smicallef/spiderfoot/archive/v2.7.0-final.tar.gz returns a **404**.
