### PR TITLE
Add a module to detect SRV records

### DIFF
--- a/modules/sfp_dnscommonsrv.py
+++ b/modules/sfp_dnscommonsrv.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Name:         sfp_dnscommonsrv
+# Purpose:      SpiderFoot plug-in for attempting to resolve through
+#               brute-forcing common SRV record.
+#
+# Author:      Michael Scherer <misc@zarb.org>
+#
+# Created:     22/08/2017
+# Copyright:   (c) Michael Scherer 2017
+# Licence:     GPL
+# -----------------------------------------------------------------------------
+
+import dns.resolver
+from sflib import SpiderFootPlugin, SpiderFootEvent
+
+
+class sfp_dnscommonsrv(SpiderFootPlugin):
+    """DNS Common SRV :Footprint,Investigate:DNS::Attempts to identify
+    hostnames through common SRV."""
+
+    # Default options
+    opts = {}
+
+    # Option descriptions
+    optdescs = {}
+
+    events = dict()
+
+    commonsrv = [ # LDAP/Kerberos, used for Active Directory
+                  # https://technet.microsoft.com/en-us/library/cc961719.aspx
+                 '_ldap._tcp',
+                 '_gc._msdcs',
+                 '_ldap._tcp.pdc._msdcs',
+                 '_ldap._tcp.gc._msdcs',
+                 '_kerberos._tcp.dc._msdcs',
+                 '_kerberos._tcp',
+                 '_kerberos._udp',
+                 '_kerberos-master._tcp',
+                 '_kerberos-master._udp',
+                 '_kpasswd._tcp',
+                 '_kpasswd._udp',
+                 '_ntp._udp',
+
+                 # SIP
+                 '_sip._tcp',
+                 '_sip._udp',
+                 '_sip._tls',
+                 '_sips._tcp',
+
+                 # STUN
+                 # https://tools.ietf.org/html/rfc5389
+                 '_stun._tcp',
+                 '_stun._udp',
+                 '_stuns._tcp',
+
+                 # TURN
+                 # https://tools.ietf.org/html/rfc5928
+                 '_turn._tcp',
+                 '_turn._udp',
+                 '_turns._tcp',
+
+                 # XMPP
+                 # http://xmpp.org/rfcs/rfc6120.html
+                 '_jabber._tcp',
+                 '_xmpp-client._tcp',
+                 '_xmpp-server._tcp']
+
+    def setup(self, sfc, userOpts=dict()):
+        self.sf = sfc
+        self.events = dict()
+        self.__dataSource__ = "DNS"
+
+    # What events is this module interested in for input
+    def watchedEvents(self):
+        return ['INTERNET_NAME', 'DOMAIN_NAME']
+
+    # What events this module produces
+    # This is to support the end user in selecting modules based on events
+    # produced.
+    def producedEvents(self):
+        return ["IP_ADDRESS", "INTERNET_NAME", "IPV6_ADDRESS"]
+
+    # Handle events sent to this module
+    def handleEvent(self, event):
+        eventName = event.eventType
+        srcModuleName = event.module
+
+        if srcModuleName == "sfp_dnscommonsrv":
+            return None
+
+        self.sf.debug("Received event, " + eventName +
+                      ", from " + srcModuleName)
+
+        eventData = event.data
+        eventDataHash = self.sf.hashstring(eventData)
+        parentEvent = event
+
+        if eventDataHash in self.events:
+            return None
+
+        self.events[eventDataHash] = True
+
+        self.sf.debug("Iterating through possible SRV records.")
+        # Try resolving common names
+        for srv in self.commonsrv:
+            if self.checkForStop():
+                return None
+
+            name = srv + "." + eventData
+
+            # Skip hosts we've processed already
+            if self.sf.hashstring(name) in self.events.keys():
+                continue
+
+            try:
+                answers = dns.resolver.query(name, 'SRV')
+            except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+                answers = []
+
+            for a in answers:
+                # Report the host
+                evt = SpiderFootEvent("INTERNET_NAME", a.target.to_text(),
+                                      self.__name__, parentEvent)
+                self.notifyListeners(evt)
+
+# End of sfp_dnscommonsrv class

--- a/modules/sfp_dnscommonsrv.py
+++ b/modules/sfp_dnscommonsrv.py
@@ -124,4 +124,7 @@ class sfp_dnscommonsrv(SpiderFootPlugin):
                                       self.__name__, parentEvent)
                 self.notifyListeners(evt)
 
+                evt = SpiderFootEvent("DNS_SRV", name,
+                                      self.__name__, parentEvent)
+                self.notifyListeners(evt)
 # End of sfp_dnscommonsrv class

--- a/sfdb.py
+++ b/sfdb.py
@@ -120,6 +120,7 @@ class SpiderFootDb:
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('DESCRIPTION_ABSTRACT', 'Description - Abstract', 0, 'DESCRIPTOR')",
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('DEVICE_TYPE', 'Device Type', 0, 'DESCRIPTOR')",
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('DNS_TEXT', 'DNS TXT Record', 0, 'DATA')",
+        "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('DNS_SRV', 'DNS SRV Record', 0, 'DATA')",
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('DNS_SPF', 'DNS SPF Record', 0, 'DATA')",
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('DOMAIN_NAME', 'Domain Name', 0, 'ENTITY')",
         "INSERT INTO tbl_event_types (event, event_descr, event_raw, event_type) VALUES ('DOMAIN_NAME_PARENT', 'Domain Name (Parent)', 0, 'ENTITY')",


### PR DESCRIPTION
This PR add a module that will try to find servers using SRV records. This can be used to find AD servers or similar interesting system for internal pentesting, or external target (such as SIP, XMPP, etc) for exteranl intelligence gathering.

It also add a new record, both for UX and to potentially later be consumed by others modules.