### PR TITLE
Updated version and added wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 #
-# Spiderfoot Dockerfile 
+# Spiderfoot Dockerfile
 #
 # http://www.spiderfoot.net
 #
 # Written by: Michael Pellon <m@pellon.io>
+# Updated by: Chandrapal <bnchandrapal@protonmail.com>
 #
 # Usage:
 #
@@ -17,7 +18,7 @@ FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y \
   build-essential \
   curl \
-  git \ 
+  git \
   libssl-dev \
   libxml2-dev \
   libxslt1-dev \
@@ -34,13 +35,14 @@ RUN apt-get update && apt-get install -y \
 RUN rm -rf /var/lib/apt/lists/* \
   && cd /usr/include/openssl/ \
   && ln -s ../x86_64-linux-gnu/openssl/opensslconf.h . \
+  && pip install wheel \
   && pip install cherrypy lxml mako netaddr
 
 # Create a dedicated/non-privileged user to run the app.
 RUN addgroup spiderfoot && \
     useradd -r -g spiderfoot -d /home/spiderfoot -s /sbin/nologin -c "SpiderFoot User" spiderfoot
 
-ENV SPIDERFOOT_VERSION 2.10
+ENV SPIDERFOOT_VERSION 2.11.0
 
 # Download the specified release.
 WORKDIR /home


### PR DESCRIPTION
I have 2 changes:
1. The version of Spiderfoot has been updated to the latest version (2.11.0 as of now)
2. Added `pip install wheel` as I had the following error:
  ```
  Running setup.py bdist_wheel for mako ... error
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-Gx291P/mako/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp2dyHevpip-wheel- --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
   ```
Now the build works fine.