### PR TITLE
add Authentication in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@
 # Written by: Michael Pellon <m@pellon.io>
 # Updated by: Chandrapal <bnchandrapal@protonmail.com>
 # Updated by: Steve Micallef <steve@binarypool.com>
+# Updated by: nancheal <nancheal@gmail.com>
 #    -> Inspired by https://github.com/combro2k/dockerfiles/tree/master/alpine-spiderfoot
 #
 # Usage:
@@ -43,5 +44,7 @@ WORKDIR /home/spiderfoot
 EXPOSE 5001
 
 # Run the application.
-ENTRYPOINT ["/usr/bin/python"] 
-CMD ["./sf.py", "0.0.0.0:5001"]
+# ENTRYPOINT ["/usr/bin/python"] 
+# CMD ["./sf.py", "0.0.0.0:5001"]
+ADD docker-entrypoint.sh /home/spiderfoot/docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # Usage:
 #
 #   sudo docker build -t spiderfoot .
-#   sudo docker run -it -p 6001:5001 spiderfoot -A admin:admin
+#   sudo docker run -it --rm -p 6001:5001 spiderfoot -A admin:admin
 
 # Pull the base image.
 FROM alpine:3.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,5 @@ WORKDIR /home/spiderfoot
 EXPOSE 5001
 
 # Run the application.
-# ENTRYPOINT ["/usr/bin/python"] 
-# CMD ["./sf.py", "0.0.0.0:5001"]
 ADD docker-entrypoint.sh /home/spiderfoot/docker-entrypoint.sh
-ENTRYPOINT [ "/docker-entrypoint.sh"]
+ENTRYPOINT [ "/home/spiderfoot/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # Usage:
 #
 #   sudo docker build -t spiderfoot .
-#   sudo docker run -it -p 5001:5001 spiderfoot
+#   sudo docker run -it -p 6001:5001 spiderfoot -A admin:admin
 
 # Pull the base image.
 FROM alpine:3.7

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+# Updated by: nancheal <nancheal@gmail.com>
 export TOP_PID=$$
 trap 'exit 1' TERM
 exit_script(){

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,30 @@
-#!/bin/bash
-Auth = ${Auth:-""}
-while getopts "pass" OPT; do
-    case $OPT in
-        pass)
-            Auth=$OPTARG;;
-    esac
-done
-if [Auth != "" ];then
-    touch passwd
-    echo $Auth >> passwd
+#!/bin/sh
+
+export TOP_PID=$$
+trap 'exit 1' TERM
+exit_script(){
+        kill -s TERM $TOP_PID
+}
+if [ $# -gt 0 ];then 
+    while getopts "A:" OPT;do
+            case $OPT in
+                    A)
+                            Auth=$OPTARG
+                            ;;
+                    \?)
+                            :|exit_script
+                            ;;
+            esac
+    done
+    echo "$Auth"|grep -q ":"
+    if [ $? -eq 0 ];then
+            echo "$Auth" >> passwd
+    else
+            echo "Your input should be in the format of 'username:password'"
+            :|exit_script
+    fi
+    /usr/bin/python sf.py 0.0.0.0:5001
+else
+    echo "spiderfoot is running without authentication"
+    /usr/bin/python sf.py 0.0.0.0:5001
 fi
-/usr/bin/python sf.py 0.0.0.0:5001

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+Auth = ${Auth:-""}
+while getopts "pass" OPT; do
+    case $OPT in
+        pass)
+            Auth=$OPTARG;;
+    esac
+done
+if [Auth != "" ];then
+    touch passwd
+    echo $Auth >> passwd
+fi
+/usr/bin/python sf.py 0.0.0.0:5001


### PR DESCRIPTION
test:
1. docker build -t spiderfoot .
2. unAuthentication mod
docker run -it --rm -p 6001:5001 spiderfoot
<img width="1264" alt="spiderfoot v2 12 2018-04-25 23-20-57" src="https://user-images.githubusercontent.com/12165569/39255544-61ac6746-48df-11e8-8c4f-cfea8d137669.png">
3. without input for option -A
<img width="616" alt="spiderfoot terminal -bash 139x40 2018-04-25 23-22-10" src="https://user-images.githubusercontent.com/12165569/39255644-9418d020-48df-11e8-9c3a-928a4ef1b0a2.png">
4. wrong input for option -A
<img width="607" alt="spiderfoot terminal -bash 139x40 2018-04-25 23-23-28" src="https://user-images.githubusercontent.com/12165569/39255693-b3b9bcbe-48df-11e8-9a08-878a84b1b836.png">
5. Authentication mod
docker run -it --rm -p 6001:5001 spiderfoot -A admin:admin
<img width="515" alt="window 2018-04-25 23-25-08" src="https://user-images.githubusercontent.com/12165569/39255800-f45835e8-48df-11e8-8229-004264159ce0.png">
