### PR TITLE
Move sfp_mnemonics to Passive DNS category

### DIFF
--- a/modules/sfp_mnemonic.py
+++ b/modules/sfp_mnemonic.py
@@ -17,7 +17,7 @@ import time
 from sflib import SpiderFoot, SpiderFootPlugin, SpiderFootEvent
 
 class sfp_mnemonic(SpiderFootPlugin):
-    """Mnemonic PassiveDNS:Footprint,Investigate,Passive:Search Engines::Obtain Passive DNS information from PassiveDNS.mnemonic.no."""
+    """Mnemonic PassiveDNS:Footprint,Investigate,Passive:Passive DNS::Obtain Passive DNS information from PassiveDNS.mnemonic.no."""
 
     # Default options
     opts = {


### PR DESCRIPTION
Move `sfp_mnemonics` from `Search Engines` to `Passive DNS` category, in line with `sfp_hackertarget` and `sfp_robtex`.

I didn't realize `Passive DNS` was a valid category at the time.
