### PR TITLE
Initial support for ReconJSON

### DIFF
--- a/dyn/scanlist.tmpl
+++ b/dyn/scanlist.tmpl
@@ -117,8 +117,12 @@
                     var efr = document.getElementById('exportframe');
                     if (type == "gexf") {
                         efr.src = '${docroot}/scanvizmulti?ids=' + ids.join(',');
-                    } else {
+                    } else if (type == "csv") {
                         efr.src = '${docroot}/scaneventresultexportmulti?ids=' + ids.join(',');
+                    } else if (type == "reconjson") {
+                        efr.src = '${docroot}/scanexportreconjsonmulti?ids=' + ids.join(',');
+                    } else {
+                        console.log("Invalid export type");
                     }
                     $("#loader").fadeOut(500);
                 }
@@ -168,7 +172,9 @@
                             buttons += "<button class='btn dropdown-toggle btn-success' data-toggle='dropdown'><span class='caret'></span></button>";
                             buttons += "<ul class='dropdown-menu'>";
                             buttons += "<li><a href='javascript:exportSelected(\"csv\")'>CSV</a></li>";
-                            buttons += "<li><a href='javascript:exportSelected(\"gexf\")'>GEXF</a></li></ul>";
+                            buttons += "<li><a href='javascript:exportSelected(\"gexf\")'>GEXF</a></li>";
+                            buttons += "<li><a href='javascript:exportSelected(\"reconjson\")'>ReconJSON</a></li>";
+                            buttons += "</ul>";
                             buttons += "</div>";
 
                             buttons += "<div class='btn-group pull-right'>";


### PR DESCRIPTION

Add support for exporting as ReconJSON

Draft / request for comments.

I'd like to see support for ReconJSON added eventually. This approach may not be the best approach. On the other hand, it may be better than nothing. In the long term, the data for each host should should probably be merged into a `dict` for each host, before dumping as JSON.

---

Supports only hosts. Does not merge results, resulting in duplicate `Hosts`. This is permitted by the specification, but probably not ideal. This approach will likely prove to be problematic in the future, with the addition of support for [Services](https://github.com/ReconJSON/ReconJSON/blob/master/Service.md) objects. Expanding upon the current approach to support exporting services would result in one `Host` entry for each open port.

Exports all data types relating to [Hosts](https://github.com/ReconJSON/ReconJSON/blob/master/Host.md) in one way or another (includes co-hosted sites, affiliates, similar domains, etc).

This does not include host groups, such as netblocks, ASN, subnets, etc.

Does not export anything related to [DNS](https://github.com/ReconJSON/ReconJSON/blob/master/DNS.md) (mx records, name servers, etc).

Does not export anything related to [Services](https://github.com/ReconJSON/ReconJSON/blob/master/Service.md) (open ports, banners, software, etc).