### PR TITLE
Catch backspace, instead of navigate go to main results page

### DIFF
--- a/dyn/newscan.tmpl
+++ b/dyn/newscan.tmpl
@@ -52,7 +52,7 @@
         <div class="control-group">
             <label class="control-label" for="scantarget">Seed Target</label>
             <div class="controls">
-                <input type="text" value="${scantarget}" data-toggle='popover' data-html=true data-animation=true data-title='Usage' data-content='The <i>Seed Target</i> can be one of the following. SpiderFoot will automatically detect the target type based on the format of your input.<br><br><b>Domain Name</b>: e.g. <i>example.com</i><br><b>IP Address</b>: e.g. <i>1.2.3.4</i><br><b>Hostname/Sub-domain</b>: e.g. <i>abc.example.com</i><br><b>Subnet</b>: e.g. <i>1.2.3.0/24</i><br><b>ASN</b>: e.g. <i>1234</i><br><b>E-mail address</b>: e.g. <i>bob@example.com</i><br><b>Human Name</b>: e.g. <i>&quot;John Smith&quot;</i> (must be in quotes)' data-placement='right' id="scantarget" name="scantarget" placeholder="Starting point for the scan.">
+                <input type="text" value="${scantarget}" data-toggle='popover' data-html=true data-animation=true data-title='Usage' data-content='The <i>Seed Target</i> can be one of the following. SpiderFoot will automatically detect the target type based on the format of your input.<br><br><b>Domain Name</b>: e.g. <i>example.com</i><br><b>IP Address</b>: e.g. <i>1.2.3.4</i><br><b>Hostname/Sub-domain</b>: e.g. <i>abc.example.com</i><br><b>Subnet</b>: e.g. <i>1.2.3.0/24</i><br><b>ASN</b>: e.g. <i>1234</i><br><b>E-mail address</b>: e.g. <i>bob@example.com</i><br><b>Human Name</b>: e.g. <i>&quot;John Smith&quot;</i> (must be in double quotes)<br><b>Company Name</b>: e.g. <i>-Coca Cola-</i> (must be in dashes)' data-placement='right' id="scantarget" name="scantarget" placeholder="Starting point for the scan.">
             </div>
         </div>
 

--- a/dyn/scaninfo.tmpl
+++ b/dyn/scaninfo.tmpl
@@ -56,6 +56,14 @@
         var dataloaders = [];
         var sharedSigma = "";
         var loadersrunning = false;
+        
+        $(document).on("keydown", function (event) {        
+		      if (event.keyCode === 8) {
+			      event.preventDefault();
+			      browseEventList("${id}");
+			    }
+		    });
+    
         var refresh = function() { browseEventList("${id}"); }
         $('#searchvalue').popover({ 'trigger': 'focus', 'placement': 'bottom'});
         $('#searchvalue').keyup(function(event) {

--- a/sflib.py
+++ b/sflib.py
@@ -1649,7 +1649,7 @@ class SpiderFootPlugin(object):
 # Class for targets
 class SpiderFootTarget(object):
     _validTypes = ["IP_ADDRESS", "NETBLOCK_OWNER", "INTERNET_NAME",
-                   "EMAILADDR", "HUMAN_NAME", "BGP_AS_OWNER" ]
+                   "EMAILADDR", "HUMAN_NAME", "BGP_AS_OWNER", "COMPANY_NAME" ]
     targetType = None
     targetValue = None
     targetAliases = list()

--- a/sflib.py
+++ b/sflib.py
@@ -570,7 +570,8 @@ class SpiderFoot:
             {"^.*@.*$": "EMAILADDR"},
             {"^\".*\"$": "HUMAN_NAME"},
             {"\d+": "BGP_AS_OWNER"},
-            {"^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$": "INTERNET_NAME"}
+            {"^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$": "INTERNET_NAME"},
+            {"^\-.*\-$": "COMPANY_NAME"}
         ]
 
         # Parse the target and set the targetType

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -784,6 +784,8 @@ class SpiderFootWebUi:
         scanId = sf.genScanInstanceGUID(scanname)
         if targetType == "HUMAN_NAME":
             scantarget = scantarget.replace("\"", "")
+        elif targetType == "COMPANY_NAME":
+            scantarget = scantarget.replace("-", "")
         else:
             scantarget = scantarget.lower()
         t = SpiderFootScanner(scanname, scantarget, targetType, scanId,


### PR DESCRIPTION
When using the backspace key when navigating through the results it will navigate back to the scans overview. This catches the button press and returns the user to the scan results overview.