### PR TITLE
Add WEB_ANALYTICS_ID to sfp_shodan watched events

### DIFF
--- a/modules/sfp_shodan.py
+++ b/modules/sfp_shodan.py
@@ -136,8 +136,14 @@ class sfp_shodan(SpiderFootPlugin):
             self.notifyListeners(evt)
 
         if eventName == 'WEB_ANALYTICS_ID':
-            network = eventData.split(": ")[0]
-            analytics_id = eventData.split(": ")[1]
+            try:
+                network = eventData.split(": ")[0]
+                analytics_id = eventData.split(": ")[1]
+            except BaseException as e:
+                self.sf.error("Unable to parse WEB_ANALYTICS_ID: " +
+                              eventData + " (" + str(e) + ")", False)
+                return None
+
             rec = self.searchHtml(analytics_id)
 
             if rec is None:

--- a/modules/sfp_shodan.py
+++ b/modules/sfp_shodan.py
@@ -21,7 +21,7 @@ class sfp_shodan(SpiderFootPlugin):
 
     # Default options
     opts = {
-        "api_key": "",
+        'api_key': "",
         'netblocklookup': True,
         'maxnetblock': 24
     }
@@ -48,7 +48,7 @@ class sfp_shodan(SpiderFootPlugin):
 
     # What events is this module interested in for input
     def watchedEvents(self):
-        return ["IP_ADDRESS", "NETBLOCK_OWNER", "DOMAIN_NAME"]
+        return ["IP_ADDRESS", "NETBLOCK_OWNER", "DOMAIN_NAME", "WEB_ANALYTICS_ID"]
 
     # What events this module produces
     def producedEvents(self):
@@ -74,7 +74,7 @@ class sfp_shodan(SpiderFootPlugin):
 
     def searchHosts(self, qry):
         res = self.sf.fetchUrl("https://api.shodan.io/shodan/host/search?query=hostname:" + qry +
-                               "?key=" + self.opts['api_key'],
+                               "&key=" + self.opts['api_key'],
                                timeout=self.opts['_fetchtimeout'], useragent="SpiderFoot")
         if res['content'] is None:
             self.sf.info("No SHODAN info found for " + qry)
@@ -88,6 +88,21 @@ class sfp_shodan(SpiderFootPlugin):
 
         return info
 
+    def searchHtml(self, qry):
+        res = self.sf.fetchUrl("https://api.shodan.io/shodan/host/search?query=http.html:" + qry +
+                               "&key=" + self.opts['api_key'],
+                               timeout=self.opts['_fetchtimeout'], useragent="SpiderFoot")
+        if res['content'] is None:
+            self.sf.info("No SHODAN info found for " + qry)
+            return None
+
+        try:
+            info = json.loads(res['content'])
+        except Exception as e:
+            self.sf.error("Error processing JSON response from SHODAN.", False)
+            return None
+
+        return info
 
     # Handle events sent to this module
     def handleEvent(self, event):
@@ -105,7 +120,7 @@ class sfp_shodan(SpiderFootPlugin):
             self.errorState = True
             return None
 
-            # Don't look up stuff twice
+        # Don't look up stuff twice
         if eventData in self.results:
             self.sf.debug("Skipping " + eventData + " as already mapped.")
             return None
@@ -119,6 +134,18 @@ class sfp_shodan(SpiderFootPlugin):
             
             evt = SpiderFootEvent("SEARCH_ENGINE_WEB_CONTENT", str(hosts), self.__name__, event)
             self.notifyListeners(evt)
+
+        if eventName == 'WEB_ANALYTICS_ID':
+            network = eventData.split(": ")[0]
+            analytics_id = eventData.split(": ")[1]
+            rec = self.searchHtml(analytics_id)
+
+            if rec is None:
+                return None
+
+            evt = SpiderFootEvent("SEARCH_ENGINE_WEB_CONTENT", str(rec), self.__name__, event)
+            self.notifyListeners(evt)
+            return None
 
         if eventName == 'NETBLOCK_OWNER':
             if not self.opts['netblocklookup']:


### PR DESCRIPTION
Add `WEB_ANALYTICS_ID` to `sfp_shodan` watched events.

Allows searching for similar sites using the same analytics IDs, such as Google analytics, by using the `http.html:` filter. Saves results as `SEARCH_ENGINE_WEB_CONTENT`.

Saving as `SEARCH_ENGINE_WEB_CONTENT` is not ideal, but this is currently what the module also does for `DOMAIN_NAME` events. Ideally, in the future, the response should be parsed and the appropriate events returned. I consider this outside the scope of this PR.

The results from this test are usually not as good as SpyOnWeb, however, it's nice to have options.

Also, **this PR ninja patches a bug** where the URL should use `&` instead of `?` which was causing the API to return `401`.
