### PR TITLE
Gracefully rescue ImportError if module no longer exists - Fix #188

### DIFF
--- a/sfscan.py
+++ b/sfscan.py
@@ -194,8 +194,13 @@ class SpiderFootScanner(threading.Thread):
                 if modName == '':
                     continue
 
-                module = __import__('modules.' + modName, globals(), locals(),
-                                    [modName])
+                try:
+                    module = __import__('modules.' + modName, globals(), locals(),
+                                        [modName])
+                except ImportError:
+                    self.ts.sf.error("Failed to load module: " + modName, False)
+                    continue
+
                 mod = getattr(module, modName)()
                 mod.__name__ = modName
 


### PR DESCRIPTION
Gracefully rescue `ImportError` if module no longer exists - Fix #188

I chose to call `self.ts.sf.error` with `False`, so as to allow the scan to continue executing despite the import error.

This seemed like the most reasonable approach, as an import error is most likely to occur either when re-running a scan after a deprecated module has been deleted from the repository, or due to a syntax error while actively developing a module, in which case it's your own fault.

On the other hand, allowing the scan to continue causes the scan to show up as `FINISHED` state, rather than `ERROR`, which may be confusing to users. Also, rescuing from `ImportError` could potentially (?) hide bugs lurking in the module code which caused the module to fail.

Ideally, the `ImportError` subclass `ModuleNotFoundError` would be used instead, however this [wasn't added until Python 3.6](https://airbrake.io/blog/python-exception-handling/importerror-and-modulenotfounderror).

Tested by running a scan with `sfp_arin` module, deleting `sfp_arin.py` and associated `sfp_arin.pyc`, then re-running the scan.

![rescue](https://user-images.githubusercontent.com/434827/57169852-9f424100-6e4c-11e9-9120-bb70915fea1d.png)
