### PR TITLE
Fix comment

### DIFF
--- a/modules/sfp_viewdns.py
+++ b/modules/sfp_viewdns.py
@@ -32,7 +32,7 @@ class sfp_viewdns(SpiderFootPlugin):
         "maxcohost": "Stop reporting co-hosted sites after this many are found, as it would likely indicate web hosting."
     }
 
-    # Be sure to.infopletely clear any class variables in setup()
+    # Be sure to completely clear any class variables in setup()
     # or you run the risk of data persisting between scan runs.
 
     results = dict()


### PR DESCRIPTION
Not sure how this happened.

Looks like a find/replace for `.info` with `.com` may have gone wrong. There are no other instances of `"to.infopletely"` in the modules directory.

It appears this typo has always existed in the `sfp_viewdns` module:

* https://github.com/smicallef/spiderfoot/blob/ed9b7fd5a9e972832d1d347235b915eeded4fb13/modules/sfp_viewdns.py
