### PR TITLE
Catch string split errors

### DIFF
--- a/modules/sfp_github.py
+++ b/modules/sfp_github.py
@@ -81,8 +81,13 @@ class sfp_github(SpiderFootPlugin):
 
         # Extract name and location from profile
         if eventName == "SOCIAL_MEDIA":
-            network = eventData.split(": ")[0]
-            name = eventData.split(": ")[1]
+            try:
+                network = eventData.split(": ")[0]
+                name = eventData.split(": ")[1]
+            except BaseException as e:
+                self.sf.error("Unable to parse SOCIAL_MEDIA: " +
+                              eventData + " (" + str(e) + ")", False)
+                return None
 
             if not network == "Github":
                 self.sf.debug("Skipping social network profile, " + name + ", as not a Github profile")

--- a/modules/sfp_myspace.py
+++ b/modules/sfp_myspace.py
@@ -89,8 +89,13 @@ class sfp_myspace(SpiderFootPlugin):
 
         # Retrieve location from MySpace profile
         if eventName == "SOCIAL_MEDIA":
-            network = eventData.split(": ")[0]
-            name = eventData.split(": ")[1]
+            try:
+                network = eventData.split(": ")[0]
+                name = eventData.split(": ")[1]
+            except BaseException as e:
+                self.sf.error("Unable to parse SOCIAL_MEDIA: " +
+                              eventData + " (" + str(e) + ")", False)
+                return None
 
             if network != "MySpace":
                 self.sf.debug("Skipping social network profile, " + name + ", as not a MySpace profile")

--- a/modules/sfp_slideshare.py
+++ b/modules/sfp_slideshare.py
@@ -57,8 +57,13 @@ class sfp_slideshare(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         # Retrieve profile
-        network = eventData.split(": ")[0]
-        name = eventData.split(": ")[1]
+        try:
+            network = eventData.split(": ")[0]
+            name = eventData.split(": ")[1]
+        except BaseException as e:
+            self.sf.error("Unable to parse SOCIAL_MEDIA: " +
+                          eventData + " (" + str(e) + ")", False)
+            return None
 
         if not network == "SlideShare":
             self.sf.debug("Skipping social network profile, " + name + ", as not a SlideShare profile")

--- a/modules/sfp_spyonweb.py
+++ b/modules/sfp_spyonweb.py
@@ -228,8 +228,13 @@ class sfp_spyonweb(SpiderFootPlugin):
 
         # Find affiliate domains for the specified Google AdSense ID or Google Analytics ID
         if eventName in [ 'WEB_ANALYTICS_ID' ]:
-            network = eventData.split(": ")[0]
-            analytics_id = eventData.split(": ")[1]
+            try:
+                network = eventData.split(": ")[0]
+                analytics_id = eventData.split(": ")[1]
+            except BaseException as e:
+                self.sf.error("Unable to parse WEB_ANALYTICS_ID: " +
+                              eventData + " (" + str(e) + ")", False)
+                return None
 
             data = dict()
             if network == 'Google AdSense':

--- a/modules/sfp_twitter.py
+++ b/modules/sfp_twitter.py
@@ -53,8 +53,13 @@ class sfp_twitter(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         # Retrieve profile
-        network = eventData.split(": ")[0]
-        name = eventData.split(": ")[1]
+        try:
+            network = eventData.split(": ")[0]
+            name = eventData.split(": ")[1]
+        except BaseException as e:
+            self.sf.error("Unable to parse SOCIAL_MEDIA: " +
+                          eventData + " (" + str(e) + ")", False)
+            return None
 
         if not network == "Twitter":
             self.sf.debug("Skipping social network profile, " + name + ", as not a Twitter profile")


### PR DESCRIPTION
Add error handling to gracefully catch potential errors when splitting `eventData` strings which (somehow) are not in the expected format.

Untested. Copy pasta.

As per https://github.com/smicallef/spiderfoot/pull/261#discussion_r281919872
