### PR TITLE
Set application/json content-type header

### DIFF
--- a/sfwebui.py
+++ b/sfwebui.py
@@ -699,8 +699,12 @@ class SpiderFootWebUi:
     def query(self, query):
         data = None
         dbh = SpiderFootDb(self.config)
+
+        cherrypy.response.headers['Content-Type'] = "application/json; charset=utf-8"
+
         if not query.lower().startswith("select"):
             return json.dumps(["ERROR", "Non-SELECTs are unpredictable and not recommended."])
+
         try:
             ret = dbh.dbh.execute(query)
             data = ret.fetchall()


### PR DESCRIPTION
Set `application/json` content-type header for `/query` route.

### PoC

```
http://127.0.0.1:5001/query?query=select+"<body+onload=alert(window.location)>"+from+sqlite_master
```

### PoC - steal config

```
http://127.0.0.1:5001/query?query=select+"
<script>
var xhttp = new XMLHttpRequest()%3b
xhttp.onreadystatechange = function() {
  if(this.readyState==4 %26%26 this.status==200) alert(this.responseText)
}%3b
xhttp.open('GET', '/query?query=select+*+from+tbl_config%253b--', true)%3b
xhttp.send()%3b
<%2fscript>"
```