### PR TITLE
Permit PHONE_NUMBER as scan target

### DIFF
--- a/dyn/newscan.tmpl
+++ b/dyn/newscan.tmpl
@@ -52,7 +52,7 @@
         <div class="control-group">
             <label class="control-label" for="scantarget">Seed Target</label>
             <div class="controls">
-                <input type="text" value="${scantarget}" data-toggle='popover' data-html=true data-animation=true data-title='Usage' data-content='The <i>Seed Target</i> can be one of the following. SpiderFoot will automatically detect the target type based on the format of your input.<br><br><b>Domain Name</b>: e.g. <i>example.com</i><br><b>IP Address</b>: e.g. <i>1.2.3.4</i><br><b>Hostname/Sub-domain</b>: e.g. <i>abc.example.com</i><br><b>Subnet</b>: e.g. <i>1.2.3.0/24</i><br><b>ASN</b>: e.g. <i>1234</i><br><b>E-mail address</b>: e.g. <i>bob@example.com</i><br><b>Human Name</b>: e.g. <i>&quot;John Smith&quot;</i> (must be in quotes)' data-placement='right' id="scantarget" name="scantarget" placeholder="Starting point for the scan.">
+                <input type="text" value="${scantarget}" data-toggle='popover' data-html=true data-animation=true data-title='Usage' data-content='The <i>Seed Target</i> can be one of the following. SpiderFoot will automatically detect the target type based on the format of your input.<br><br><b>Domain Name</b>: e.g. <i>example.com</i><br><b>IP Address</b>: e.g. <i>1.2.3.4</i><br><b>Hostname/Sub-domain</b>: e.g. <i>abc.example.com</i><br><b>Subnet</b>: e.g. <i>1.2.3.0/24</i><br><b>ASN</b>: e.g. <i>1234</i><br><b>E-mail address</b>: e.g. <i>bob@example.com</i><br><b>Phone Number</b>: e.g. <i>+12345678901</i> (E.164 format)<br><b>Human Name</b>: e.g. <i>&quot;John Smith&quot;</i> (must be in quotes)' data-placement='right' id="scantarget" name="scantarget" placeholder="Starting point for the scan.">
             </div>
         </div>
 

--- a/sflib.py
+++ b/sflib.py
@@ -569,6 +569,7 @@ class SpiderFoot:
             {"^\d+\.\d+\.\d+\.\d+$": "IP_ADDRESS"},
             {"^\d+\.\d+\.\d+\.\d+/\d+$": "NETBLOCK_OWNER"},
             {"^.*@.*$": "EMAILADDR"},
+            {"^\+\d+$": "PHONE_NUMBER"},
             {"^\".*\"$": "HUMAN_NAME"},
             {"\d+": "BGP_AS_OWNER"},
             {"^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$": "INTERNET_NAME"}
@@ -1554,7 +1555,7 @@ class SpiderFootPlugin(object):
 # Class for targets
 class SpiderFootTarget(object):
     _validTypes = ["IP_ADDRESS", "NETBLOCK_OWNER", "INTERNET_NAME",
-                   "EMAILADDR", "HUMAN_NAME", "BGP_AS_OWNER" ]
+                   "EMAILADDR", "HUMAN_NAME", "BGP_AS_OWNER", 'PHONE_NUMBER']
     targetType = None
     targetValue = None
     targetAliases = list()


### PR DESCRIPTION
Permit `PHONE_NUMBER` as scan target.

Using a phone number as a scan target is now viable with the modifications to `sfp_phone` (#276) and `sfp_neutrinoapi` (#280) modules, and addition of `sfp_numverify` (#275) and `sfp_numinfo` (#283) modules.

It's also an easy regex which shouldn't result in false positive matches. It could be improved by using the `python-phonenumbers` library to validate the user input.
