### PR TITLE
Fix passwd and cert file checks

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -374,15 +374,30 @@ if __name__ == '__main__':
         'tools.staticdir.dir': os.path.join(currentDir, 'static')
     }}
 
-    if os.path.isfile(sf.myPath() + '/passwd'):
+    passwd_file = sf.myPath() + '/passwd'
+    if os.path.isfile(passwd_file):
+        if not os.access(passwd_file, os.R_OK):
+            print "Could not read passwd file. Permission denied."
+            sys.exit(-1)
+
         secrets = dict()
-        pw = file(sf.myPath() + '/passwd', 'r')
+
+        pw = file(passwd_file, 'r')
+
         for line in pw.readlines():
+            if ':' not in line:
+                continue
+
             u, p = line.strip().split(":")
-            if None in [u, p]:
-                print "Incorrect format of passwd file, must be username:password on each line."
-                sys.exit(-1)
+
+            if not u or not p:
+                continue
+
             secrets[u] = p
+
+        if not secrets:
+            print "Incorrect format of passwd file, must be username:password on each line."
+            sys.exit(-1)
 
         print "Enabling authentication based on supplied passwd file."
         conf['/'] = {

--- a/sf.py
+++ b/sf.py
@@ -408,12 +408,21 @@ if __name__ == '__main__':
         else:
             print "Warning: passwd file contains no passwords. Authentication disabled."
 
-    if os.path.isfile(sf.myPath() + '/spiderfoot.key') and \
-       os.path.isfile(sf.myPath() + '/spiderfoot.crt'):
+    key_path = sf.myPath() + '/spiderfoot.key'
+    crt_path = sf.myPath() + '/spiderfoot.crt'
+    if os.path.isfile(key_path) and os.path.isfile(crt_path):
+        if not os.access(crt_path, os.R_OK):
+            print "Could not read spiderfoot.crt file. Permission denied."
+            sys.exit(-1)
+
+        if not os.access(key_path, os.R_OK):
+            print "Could not read spiderfoot.key file. Permission denied."
+            sys.exit(-1)
+
         print "Enabling SSL based on supplied key and certificate file."
         cherrypy.server.ssl_module = 'builtin'
-        cherrypy.server.ssl_certificate = sf.myPath() + '/spiderfoot.crt'
-        cherrypy.server.ssl_private_key = sf.myPath() + '/spiderfoot.key'
+        cherrypy.server.ssl_certificate = crt_path
+        cherrypy.server.ssl_private_key = key_path
 
     # Try starting the web server. If it fails due to a database being
     # missing, start a smaller web server just for setting up the DB.

--- a/sf.py
+++ b/sf.py
@@ -386,18 +386,16 @@ if __name__ == '__main__':
 
         for line in pw.readlines():
             if ':' not in line:
-                continue
+                print "Incorrect format of passwd file, must be username:password on each line."
+                sys.exit(-1)
 
             u, p = line.strip().split(":")
 
             if not u or not p:
-                continue
+                print "Incorrect format of passwd file, must be username:password on each line."
+                sys.exit(-1)
 
             secrets[u] = p
-
-        if not secrets:
-            print "Incorrect format of passwd file, must be username:password on each line."
-            sys.exit(-1)
 
         print "Enabling authentication based on supplied passwd file."
         conf['/'] = {

--- a/sf.py
+++ b/sf.py
@@ -397,13 +397,16 @@ if __name__ == '__main__':
 
             secrets[u] = p
 
-        print "Enabling authentication based on supplied passwd file."
-        conf['/'] = {
-            'tools.auth_digest.on': True,
-            'tools.auth_digest.realm': sfConfig['__webaddr'],
-            'tools.auth_digest.get_ha1': auth_digest.get_ha1_dict_plain(secrets),
-            'tools.auth_digest.key': random.randint(0, 99999999)
-        }
+        if secrets:
+            print "Enabling authentication based on supplied passwd file."
+            conf['/'] = {
+                'tools.auth_digest.on': True,
+                'tools.auth_digest.realm': sfConfig['__webaddr'],
+                'tools.auth_digest.get_ha1': auth_digest.get_ha1_dict_plain(secrets),
+                'tools.auth_digest.key': random.randint(0, 99999999)
+            }
+        else:
+            print "Warning: passwd file contains no passwords. Authentication disabled."
 
     if os.path.isfile(sf.myPath() + '/spiderfoot.key') and \
        os.path.isfile(sf.myPath() + '/spiderfoot.crt'):


### PR DESCRIPTION
Check `passwd` file is readable, and prevent the follow stacktrace caused by malformed passwd entries:

```
$ ./sf.py 
Attempting to verify database and update if necessary...
Starting web server at http://127.0.0.1:5001 ...
Traceback (most recent call last):
  File "./sf.py", line 381, in <module>
    u, p = line.strip().split(":")
ValueError: need more than 1 value to unpack
```
