### PR TITLE
pylint: disable=no-member

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -352,7 +352,7 @@ class SpiderFootCli(cmd.Cmd):
                              data = post
                     )
             self.ddprint("Response: " + str(r))
-            if r.status_code == requests.codes.ok:
+            if r.status_code == requests.codes.ok:  #pylint: disable=no-member
                 return r.text
             else:
                 r.raise_for_status()


### PR DESCRIPTION
```
https://github.com/PyCQA/pylint/issues/1411
```

**Before**

```
# pylint -E sfcli.py 
Using config file /root/Desktop/spiderfoot/.pylintrc
************* Module sfcli
sfcli.py:355: [E1101(no-member), SpiderFootCli.request] Instance of 'LookupDict' has no 'ok' member
```

**After**

```
# pylint -E sfcli.py 
Using config file /root/Desktop/spiderfoot/.pylintrc
```
