### PR TITLE
from io import StringIO

### DIFF
--- a/sfwebui.py
+++ b/sfwebui.py
@@ -23,7 +23,7 @@ from mako.template import Template
 from sfdb import SpiderFootDb
 from sflib import SpiderFoot, globalScanStatus
 from sfscan import SpiderFootScanner
-from StringIO import StringIO
+from io import StringIO
 
 
 class SpiderFootWebUi:


### PR DESCRIPTION
http://python-future.org/compatible_idioms.html#stringio

Libraries and `ext` dependencies also need to be reviewed:

```
# grep -rn "from StringIO "
modules/sfp_filemeta.py:19:from StringIO import StringIO
sfwebui.py:26:from StringIO import StringIO
ext/stem/control.py:253:  from StringIO import StringIO
ext/stem/response/__init__.py:50:  from StringIO import StringIO
```