### PR TITLE
Fix sfp_sslcert handling of IP_ADDRESS events

### DIFF
--- a/modules/sfp_sslcert.py
+++ b/modules/sfp_sslcert.py
@@ -73,6 +73,9 @@ class sfp_sslcert(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if eventName == "LINKED_URL_INTERNAL":
+            if not eventData.lower().startswith("https://") and not self.opts['tryhttp']:
+                return None
+
             fqdn = self.sf.urlFQDN(eventData.lower())
         else:
             fqdn = eventData
@@ -80,12 +83,6 @@ class sfp_sslcert(SpiderFootPlugin):
         if fqdn not in self.results:
             self.results[fqdn] = True
         else:
-            return None
-
-        if eventName == "IP_ADDRESS":
-            fqdn = "https://" + eventData
-
-        if not eventData.lower().startswith("https://") and not self.opts['tryhttp']:
             return None
 
         port = 443


### PR DESCRIPTION
This PR fixes a bug in the `sfp_sslcert` module handling of `IP_ADDRESS` events.

The module prepended a URL scheme to the FQDN:

```python
        if eventName == "IP_ADDRESS":
            fqdn = "https://" + eventData
```

And then attempts to use this string in a TCP socket `connect` call, which will obviously fail, resulting in the following error:

```
Unable to SSL-connect to https://xx.xx.xx.xx
```

Fixing this required moving the `self.opts['tryhttp']` check to the `if eventName == "LINKED_URL_INTERNAL":` conditional, which is where it belonged anyway, as this option is irrelevant for the other events this module watches (`INTERNET_NAME`, `IP_ADDRESS`).
