### PR TITLE
Print debug message when event is ignored

### DIFF
--- a/modules/sfp_accounts.py
+++ b/modules/sfp_accounts.py
@@ -208,7 +208,7 @@ class sfp_accounts(SpiderFootPlugin):
 
         # Skip events coming from me unless they are USERNAME events
         if eventName != "USERNAME" and srcModuleName == "sfp_accounts":
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         if eventData not in self.results.keys():

--- a/modules/sfp_accounts.py
+++ b/modules/sfp_accounts.py
@@ -208,6 +208,7 @@ class sfp_accounts(SpiderFootPlugin):
 
         # Skip events coming from me unless they are USERNAME events
         if eventName != "USERNAME" and srcModuleName == "sfp_accounts":
+            self.sf.debug("Ignoring " + eventData + ", from self.")
             return None
 
         if eventData not in self.results.keys():

--- a/modules/sfp_bingsharedip.py
+++ b/modules/sfp_bingsharedip.py
@@ -92,7 +92,7 @@ class sfp_bingsharedip(SpiderFootPlugin):
         # Ignore IP addresses from myself as they are just for creating
         # a link from the netblock to the co-host.
         if eventName == "IP_ADDRESS" and srcModuleName == "sfp_bingsharedip":
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         if self.cohostcount > self.opts['maxcohost']:

--- a/modules/sfp_bingsharedip.py
+++ b/modules/sfp_bingsharedip.py
@@ -81,6 +81,7 @@ class sfp_bingsharedip(SpiderFootPlugin):
         srcModuleName = event.module
         eventData = event.data
         self.currentEventSrc = event
+
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         # Don't look up stuff twice
@@ -91,6 +92,7 @@ class sfp_bingsharedip(SpiderFootPlugin):
         # Ignore IP addresses from myself as they are just for creating
         # a link from the netblock to the co-host.
         if eventName == "IP_ADDRESS" and srcModuleName == "sfp_bingsharedip":
+            self.sf.debug("Ignoring " + eventData + ", from self.")
             return None
 
         if self.cohostcount > self.opts['maxcohost']:

--- a/modules/sfp_circllu.py
+++ b/modules/sfp_circllu.py
@@ -131,7 +131,7 @@ class sfp_circllu(SpiderFootPlugin):
 
         # Ignore messages from myself
         if srcModuleName == "sfp_circllu":
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         if self.opts['api_key_login'] == "" or self.opts['api_key_password'] == "":

--- a/modules/sfp_circllu.py
+++ b/modules/sfp_circllu.py
@@ -127,11 +127,12 @@ class sfp_circllu(SpiderFootPlugin):
         if self.errorState:
             return None
 
+        self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
+
         # Ignore messages from myself
         if srcModuleName == "sfp_circllu":
+            self.sf.debug("Ignoring " + eventData + ", from self.")
             return None
-
-        self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if self.opts['api_key_login'] == "" or self.opts['api_key_password'] == "":
             self.sf.error("You enabled sfp_circllu but did not set an credentials!", False)

--- a/modules/sfp_dnscommonsrv.py
+++ b/modules/sfp_dnscommonsrv.py
@@ -84,14 +84,15 @@ class sfp_dnscommonsrv(SpiderFootPlugin):
     def handleEvent(self, event):
         eventName = event.eventType
         srcModuleName = event.module
-
-        if srcModuleName == "sfp_dnscommonsrv":
-            return None
+        eventData = event.data
 
         self.sf.debug("Received event, " + eventName +
                       ", from " + srcModuleName)
 
-        eventData = event.data
+        if srcModuleName == "sfp_dnscommonsrv":
+            self.sf.debug("Ignoring " + eventData + ", from self.")
+            return None
+
         eventDataHash = self.sf.hashstring(eventData)
         parentEvent = event
 

--- a/modules/sfp_dnscommonsrv.py
+++ b/modules/sfp_dnscommonsrv.py
@@ -90,7 +90,7 @@ class sfp_dnscommonsrv(SpiderFootPlugin):
                       ", from " + srcModuleName)
 
         if srcModuleName == "sfp_dnscommonsrv":
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         eventDataHash = self.sf.hashstring(eventData)

--- a/modules/sfp_dnszonexfer.py
+++ b/modules/sfp_dnszonexfer.py
@@ -62,6 +62,7 @@ class sfp_dnszonexfer(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if srcModuleName == "sfp_dnszonexfer":
+            self.sf.debug("Ignoring " + eventData + ", from self.")
             return None
 
         if eventDataHash in self.events:

--- a/modules/sfp_dnszonexfer.py
+++ b/modules/sfp_dnszonexfer.py
@@ -62,7 +62,7 @@ class sfp_dnszonexfer(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if srcModuleName == "sfp_dnszonexfer":
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         if eventDataHash in self.events:

--- a/modules/sfp_hackertarget.py
+++ b/modules/sfp_hackertarget.py
@@ -189,6 +189,7 @@ class sfp_hackertarget(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if srcModuleName == "sfp_hackertarget" and eventName == "IP_ADDRESS":
+            self.sf.debug("Ignoring " + eventData + ", from self.")
             return None
 
         # Don't look up stuff twice

--- a/modules/sfp_hackertarget.py
+++ b/modules/sfp_hackertarget.py
@@ -189,7 +189,7 @@ class sfp_hackertarget(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if srcModuleName == "sfp_hackertarget" and eventName == "IP_ADDRESS":
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         # Don't look up stuff twice

--- a/modules/sfp_peegeepee.py
+++ b/modules/sfp_peegeepee.py
@@ -131,7 +131,7 @@ class sfp_peegeepee(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if srcModuleName == 'sfp_peegeepee':
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         if eventData in self.results:

--- a/modules/sfp_riskiq.py
+++ b/modules/sfp_riskiq.py
@@ -147,7 +147,7 @@ class sfp_riskiq(SpiderFootPlugin):
 
         # Ignore messages from myself
         if srcModuleName == "sfp_riskiq":
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         if self.opts['api_key_login'] == "" or self.opts['api_key_password'] == "":

--- a/modules/sfp_riskiq.py
+++ b/modules/sfp_riskiq.py
@@ -143,11 +143,12 @@ class sfp_riskiq(SpiderFootPlugin):
         if self.errorState:
             return None
 
+        self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
+
         # Ignore messages from myself
         if srcModuleName == "sfp_riskiq":
+            self.sf.debug("Ignoring " + eventData + ", from self.")
             return None
-
-        self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if self.opts['api_key_login'] == "" or self.opts['api_key_password'] == "":
             self.sf.error("You enabled sfp_riskiq but did not set an credentials!", False)

--- a/modules/sfp_robtex.py
+++ b/modules/sfp_robtex.py
@@ -91,6 +91,7 @@ class sfp_robtex(SpiderFootPlugin):
             return None
 
         if srcModuleName == "sfp_robtex" and eventName == "IP_ADDRESS":
+            self.sf.debug("Ignoring " + eventData + ", from self.")
             return None
 
         # Don't look up stuff twice

--- a/modules/sfp_robtex.py
+++ b/modules/sfp_robtex.py
@@ -91,7 +91,7 @@ class sfp_robtex(SpiderFootPlugin):
             return None
 
         if srcModuleName == "sfp_robtex" and eventName == "IP_ADDRESS":
-            self.sf.debug("Ignoring " + eventData + ", from self.")
+            self.sf.debug("Ignoring " + eventName + ", from self.")
             return None
 
         # Don't look up stuff twice

--- a/modules/sfp_spider.py
+++ b/modules/sfp_spider.py
@@ -256,7 +256,7 @@ class sfp_spider(SpiderFootPlugin):
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
         if eventData in self.urlEvents:
-            self.sf.debug("Ignoring " + eventData + " as already spidered or is being spidered.")
+            self.sf.debug("Ignoring " + eventName + " as already spidered or is being spidered.")
             return None
 
         # Don't spider links we find ourselves, obviously

--- a/modules/sfp_spider.py
+++ b/modules/sfp_spider.py
@@ -258,12 +258,13 @@ class sfp_spider(SpiderFootPlugin):
         if eventData in self.urlEvents:
             self.sf.debug("Ignoring " + eventData + " as already spidered or is being spidered.")
             return None
-        else:
-            self.urlEvents[eventData] = event
 
         # Don't spider links we find ourselves, obviously
         if eventName == "LINKED_URL_INTERNAL" and "sfp_spider" in srcModuleName:
+            self.sf.debug("Ignoring " + eventData + ", from self.")
             return None
+
+        self.urlEvents[eventData] = event
 
         # Determine where to start spidering from if it's a INTERNET_NAME event
         if eventName == "INTERNET_NAME":


### PR DESCRIPTION
Print debug message when event is ignored.

Also, ensure `"Received event, " + eventName + ", from " + srcModuleName` is printed, regardless of whether the event is ignored.

Untested.