### PR TITLE
Quote http.html filter query

### DIFF
--- a/modules/sfp_shodan.py
+++ b/modules/sfp_shodan.py
@@ -11,6 +11,7 @@
 # -------------------------------------------------------------------------------
 
 import json
+import urllib
 from netaddr import IPNetwork
 from sflib import SpiderFoot, SpiderFootPlugin, SpiderFootEvent
 
@@ -89,8 +90,12 @@ class sfp_shodan(SpiderFootPlugin):
         return info
 
     def searchHtml(self, qry):
-        res = self.sf.fetchUrl("https://api.shodan.io/shodan/host/search?query=http.html:" + qry +
-                               "&key=" + self.opts['api_key'],
+        params = {
+            'query': 'http.html:"' + qry.encode('raw_unicode_escape') + '"',
+            'key': self.opts['api_key']
+        }
+
+        res = self.sf.fetchUrl("https://api.shodan.io/shodan/host/search?" + urllib.urlencode(params),
                                timeout=self.opts['_fetchtimeout'], useragent="SpiderFoot")
         if res['content'] is None:
             self.sf.info("No SHODAN info found for " + qry)


### PR DESCRIPTION
Small bug fix.

`http.html` filter worked fine for simple strings such as Google Analytics IDs, but fails on more complex strings which contain characters such as '+', likely due to URL encoding.

Using quotes around the query, in combination with `urllib.encode` resolves this.
