### PR TITLE
Catch KeyboardInterrupt for prettier exiting

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -1236,5 +1236,9 @@ if __name__ == "__main__":
         except BaseException as e:
             pass
 
-    s.dprint("Type 'help' or '?'.")
-    s.cmdloop()
+    try:
+        s.dprint("Type 'help' or '?'.")
+        s.cmdloop()
+    except KeyboardInterrupt:
+        print("\n")
+        sys.exit(0)


### PR DESCRIPTION
Alternatively, rather than exiting, you may want to silently catch `KeyboardInterrupt`, and print a nice `yo, type exit to exit` message.