### PR TITLE
Validate ids POST param for scanexportjsonmulti

### DIFF
--- a/sfwebui.py
+++ b/sfwebui.py
@@ -188,7 +188,12 @@ class SpiderFootWebUi:
         scaninfo = dict()
 
         for id in ids.split(','):
-          scan_name = dbh.scanInstanceGet(id)[0]
+          scan = dbh.scanInstanceGet(id)
+
+          if scan is None:
+              continue
+
+          scan_name = scan[0]
 
           if scan_name not in scaninfo:
               scaninfo[scan_name] = []


### PR DESCRIPTION
Prior to this PR, the following request would cause a HTTP 500 Internal Server Error.

```
curl -isk -X POST http://127.0.0.1:5001/scanexportjsonmulti -d "ids=anything"
```

This PR ensures empty JSON is returned instead:

```
HTTP/1.1 200 OK
Content-Length: 2
Content-Disposition: attachment; filename=SpiderFoot.json
Server: CherryPy/17.4.1
Pragma: no-cache
Date: Sun, 14 Jul 2019 15:56:02 GMT
Content-Type: application/json; charset=utf-8

{}
```
