### PR TITLE
Whitelist useful analytics networks

### DIFF
--- a/modules/sfp_shodan.py
+++ b/modules/sfp_shodan.py
@@ -149,6 +149,10 @@ class sfp_shodan(SpiderFootPlugin):
                               eventData + " (" + str(e) + ")", False)
                 return None
 
+            if network not in ['Google AdSense', 'Google Analytics', 'Google Site Verification']:
+                self.sf.debug("Skipping " + eventData + ", as not supported.")
+                return None
+
             rec = self.searchHtml(analytics_id)
 
             if rec is None:


### PR DESCRIPTION
Whitelist useful analytics networks for Shodan.

The majority of the analytics IDs currently supported are based on DNS `TXT` records, which won't appear in Shodan using `http.html` filter.
