### PR TITLE
Use HTTPS

### DIFF
--- a/modules/sfp_archiveorg.py
+++ b/modules/sfp_archiveorg.py
@@ -114,7 +114,7 @@ class sfp_archiveorg(SpiderFootPlugin):
             newDate = datetime.datetime.now() - datetime.timedelta(days=int(daysback))
             maxDate = newDate.strftime("%Y%m%d")
 
-            url = "http://archive.org/wayback/available?url=" + eventData + \
+            url = "https://archive.org/wayback/available?url=" + eventData + \
                   "&timestamp=" + maxDate
             res = self.sf.fetchUrl(url, timeout=self.opts['_fetchtimeout'], 
                                    useragent=self.opts['_useragent'])

--- a/modules/sfp_citadel.py
+++ b/modules/sfp_citadel.py
@@ -66,7 +66,7 @@ class sfp_citadel(SpiderFootPlugin):
             if not apikey:
                 # Public API key
                 apikey = "3edfb5603418f101926c64ca5dd0e409"
-            url = "http://leak-lookup.com/api/search" 
+            url = "https://leak-lookup.com/api/search"
             postdata = "key={}&type=email_address&query={}".format( apikey, eventData ) 
  
             res = self.sf.fetchUrl(url, postData=postdata, timeout=self.opts['timeout'], 

--- a/modules/sfp_hackertarget.py
+++ b/modules/sfp_hackertarget.py
@@ -204,7 +204,7 @@ class sfp_hackertarget(SpiderFootPlugin):
 
     # Reverse lookup hosts on the same IP address
     def reverseIpLookup(self, ip):
-        res = self.sf.fetchUrl("http://api.hackertarget.com/reverseiplookup/?q=" + ip,
+        res = self.sf.fetchUrl("https://api.hackertarget.com/reverseiplookup/?q=" + ip,
                                useragent=self.opts['_useragent'],
                                timeout=self.opts['_fetchtimeout'])
         if res['content'] is None:

--- a/modules/sfp_threatcrowd.py
+++ b/modules/sfp_threatcrowd.py
@@ -76,13 +76,13 @@ class sfp_threatcrowd(SpiderFootPlugin):
         url = None
 
         if self.sf.validIP(qry):
-            url = "http://www.threatcrowd.org/searchApi/v2/ip/report/?ip=" + qry
+            url = "https://www.threatcrowd.org/searchApi/v2/ip/report/?ip=" + qry
         
         if "@" in qry:
-            url = "http://www.threatcrowd.org/searchApi/v2/email/report/?email=" + qry
+            url = "https://www.threatcrowd.org/searchApi/v2/email/report/?email=" + qry
         
         if not url:
-            url = "http://www.threatcrowd.org/searchApi/v2/domain/report/?domain=" + qry
+            url = "https://www.threatcrowd.org/searchApi/v2/domain/report/?domain=" + qry
 
         res = self.sf.fetchUrl(url, timeout=self.opts['_fetchtimeout'], useragent="SpiderFoot")
 

--- a/modules/sfp_zoneh.py
+++ b/modules/sfp_zoneh.py
@@ -113,7 +113,7 @@ class sfp_zoneh(SpiderFootPlugin):
         if self.checkForStop():
             return None
 
-        url = "http://www.zone-h.org/rss/specialdefacements"
+        url = "https://www.zone-h.org/rss/specialdefacements"
         content = self.sf.cacheGet("sfzoneh", 48)
         if content is None:
             data = self.sf.fetchUrl(url, useragent=self.opts['_useragent'])


### PR DESCRIPTION
Update several data sources to use HTTPS.

Each of the following URLs has been tested, manually, to ensure HTTPS is supported. They have not been tested using Spiderfoot. It is possible that switching to HTTPS results in a slower query time, which may or may not require an adjustment to the connection timeout option.
