### PR TITLE
Use random.SystemRandom()

### DIFF
--- a/modules/sfp_accounts.py
+++ b/modules/sfp_accounts.py
@@ -226,7 +226,7 @@ class sfp_accounts(SpiderFootPlugin):
         # sites are by attempting to fetch a garbage user.
         if not self.distrustedChecked:
             randpool = 'abcdefghijklmnopqrstuvwxyz1234567890'
-            randuser = ''.join([random.choice(randpool) for x in range(10)])
+            randuser = ''.join([random.SystemRandom().choice(randpool) for x in range(10)])
             res = self.batchSites(randuser)
             if len(res) > 0:
                 delsites = list()

--- a/modules/sfp_dnsbrute.py
+++ b/modules/sfp_dnsbrute.py
@@ -121,7 +121,7 @@ class sfp_dnsbrute(SpiderFootPlugin):
         # Spawn threads for scanning
         self.sf.info("Spawning threads to check hosts: " + str(hostList))
         for name in hostList:
-            tn = 'sfp_dnsbrute_' + str(random.randint(0, 999999999))
+            tn = 'sfp_dnsbrute_' + str(random.SystemRandom().randint(0, 999999999))
             t.append(threading.Thread(name=tn, target=self.tryHost, args=(name,)))
             t[i].start()
             i += 1

--- a/modules/sfp_junkfiles.py
+++ b/modules/sfp_junkfiles.py
@@ -65,7 +65,7 @@ class sfp_junkfiles(SpiderFootPlugin):
     # Test how trustworthy a result is
     def checkValidity(self, junkUrl):
         # Try and fetch an obviously missing version of the junk file
-        fetch = junkUrl + str(random.randint(0, 99999999))
+        fetch = junkUrl + str(random.SystemRandom().randint(0, 99999999))
         res = self.sf.fetchUrl(fetch, headOnly=True,
                                timeout=self.opts['_fetchtimeout'],
                                useragent=self.opts['_useragent'])

--- a/modules/sfp_portscan_tcp.py
+++ b/modules/sfp_portscan_tcp.py
@@ -74,7 +74,7 @@ class sfp_portscan_tcp(SpiderFootPlugin):
         self.portlist = [int(x) for x in self.portlist]
 
         if self.opts['randomize']:
-            random.shuffle(self.portlist)
+            random.SystemRandom().shuffle(self.portlist)
 
     # What events is this module interested in for input
     def watchedEvents(self):

--- a/modules/sfp_tldsearch.py
+++ b/modules/sfp_tldsearch.py
@@ -82,7 +82,7 @@ class sfp_tldsearch(SpiderFootPlugin):
         self.sf.info("Spawning threads to check TLDs: " + str(tldList))
         for pair in tldList:
             (domain, tld) = pair
-            tn = 'sfp_tldsearch_' + str(random.randint(0, 999999999))
+            tn = 'sfp_tldsearch_' + str(random.SystemRandom().randint(0, 999999999))
             t.append(threading.Thread(name=tn, target=self.tryTld, args=(domain, tld,)))
             t[i].start()
             i += 1

--- a/sf.py
+++ b/sf.py
@@ -408,7 +408,7 @@ if __name__ == '__main__':
                 'tools.auth_digest.on': True,
                 'tools.auth_digest.realm': sfConfig['__webaddr'],
                 'tools.auth_digest.get_ha1': auth_digest.get_ha1_dict_plain(secrets),
-                'tools.auth_digest.key': random.randint(0, 99999999)
+                'tools.auth_digest.key': random.SystemRandom().randint(0, 99999999)
             }
         else:
             print("Warning: passwd file contains no passwords. Authentication disabled.")

--- a/sflib.py
+++ b/sflib.py
@@ -243,8 +243,8 @@ class SpiderFoot:
                     col = "#f00"
                 ret['nodes'].append({'id': str(ncounter),
                                     'label': unicode(dst, errors="replace"),
-                                    'x': random.randint(1,1000),
-                                    'y': random.randint(1,1000),
+                                    'x': random.SystemRandom().randint(1, 1000),
+                                    'y': random.SystemRandom().randint(1, 1000),
                                     'size': "1",
                                     'color': col
                 })
@@ -256,8 +256,8 @@ class SpiderFoot:
                 ncounter = ncounter + 1
                 ret['nodes'].append({'id': str(ncounter),
                                     'label': unicode(src, errors="replace"),
-                                    'x': random.randint(1,1000),
-                                    'y': random.randint(1,1000),
+                                    'x': random.SystemRandom().randint(1, 1000),
+                                    'y': random.SystemRandom().randint(1, 1000),
                                     'size': "1",
                                     'color': col
                 })
@@ -287,9 +287,9 @@ class SpiderFoot:
  #       hashStr = hashlib.sha256(
  #           scanName +
  #           str(time.time() * 1000) +
- #           str(random.randint(100000, 999999))
+ #           str(random.SystemRandom().randint(100000, 999999))
  #       ).hexdigest()
-        rstr = str(time.time()) + str(random.randint(100000, 999999))
+        rstr = str(time.time()) + str(random.SystemRandom().randint(100000, 999999))
         hashStr = "%08X" % int(binascii.crc32(rstr) & 0xffffffff)
         return hashStr
 
@@ -1089,7 +1089,7 @@ class SpiderFoot:
         try:
             header = dict()
             if type(useragent) is list:
-                header['User-Agent'] = random.choice(useragent)
+                header['User-Agent'] = random.SystemRandom().choice(useragent)
             else:
                 header['User-Agent'] = useragent
 
@@ -1191,7 +1191,7 @@ class SpiderFoot:
     # Check if wildcard DNS is enabled by looking up two random hostnames
     def checkDnsWildcard(self, target):
         randpool = 'bcdfghjklmnpqrstvwxyz3456789'
-        randhost = ''.join([random.choice(randpool) for x in range(10)])
+        randhost = ''.join([random.SystemRandom().choice(randpool) for x in range(10)])
 
         # An exception will be raised if the resolution fails
         try:
@@ -1670,7 +1670,7 @@ class SpiderFootEvent(object):
 
         self.sourceEventHash = sourceEvent.getHash()
         self.__id = self.eventType + str(self.generated) + self.module + \
-                    str(random.randint(0, 99999999))
+                    str(random.SystemRandom().randint(0, 99999999))
 
     def asDict(self):
         return {

--- a/sfscan.py
+++ b/sfscan.py
@@ -35,7 +35,7 @@ class SpiderFootScanner(threading.Thread):
 
         # Initialize the thread
         threading.Thread.__init__(self, name="SF_" + scanId + \
-                                             str(random.randint(100000, 999999)))
+                                             str(random.SystemRandom().randint(100000, 999999)))
 
         # Temporary data to be used in startScan
         self.temp = dict()

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -458,7 +458,7 @@ class SpiderFootWebUi:
     # Settings
     def opts(self):
         templ = Template(filename='dyn/opts.tmpl', lookup=self.lookup)
-        self.token = random.randint(0, 99999999)
+        self.token = random.SystemRandom().randint(0, 99999999)
         return templ.render(opts=self.config, pageid='SETTINGS', token=self.token, docroot=self.docroot)
 
     opts.exposed = True
@@ -485,7 +485,7 @@ class SpiderFootWebUi:
     # Settings
     def optsraw(self):
         ret = dict()
-        self.token = random.randint(0, 99999999)
+        self.token = random.SystemRandom().randint(0, 99999999)
         for opt in self.config:
             if opt.startswith('__'):
                 if opt == '__modules__':
@@ -598,7 +598,7 @@ class SpiderFootWebUi:
             return self.error("Processing one or more of your inputs failed: " + str(e))
 
         templ = Template(filename='dyn/opts.tmpl', lookup=self.lookup)
-        self.token = random.randint(0, 99999999)
+        self.token = random.SystemRandom().randint(0, 99999999)
         return templ.render(opts=self.config, pageid='SETTINGS', updated=True,
                             docroot=self.docroot, token=self.token)
 


### PR DESCRIPTION
Use `random.SystemRandom()` rather than `random`.

Keeps `dlint` happy. Most of these changes don't require system randomness, but shouldn't hurt.

```
$ python2 -m flake8 --select=DUO *.py 
```