### PR TITLE
Allow event data and search results tables to be sortable

### DIFF
--- a/dyn/scaninfo.tmpl
+++ b/dyn/scaninfo.tmpl
@@ -162,7 +162,7 @@
                             if (data.length == 0) {
                                 var table = "<div id='scansummary-content'>&nbsp;&nbsp;No results found. Try broadening your search criteria.</div>";
                             } else {
-                                var table = "<table id='scansummary-content' class='table table-bordered table-striped small'><thead><tr>";
+                                var table = "<table id='scansummary-content' class='table table-bordered table-striped tablesorter small'><thead><tr>";
                                 if (typeName == null) {
                                     table += "<th>Data Element Type</th>";
                                 }
@@ -186,6 +186,7 @@
                             }
                             $("#loader").fadeOut(500);
                             $("#mainbody").append(crumbs + table);
+                            $("#scansummary-content").tablesorter();
             });
         }
 
@@ -482,7 +483,7 @@
                             }
                             crumbs += "</ul>";
 
-                            var table = "<table id='scansummary-content' class='table table-bordered table-striped small'>";
+                            var table = "<table id='scansummary-content' class='table table-bordered table-striped tablesorter small'>";
                             table += "<thead><tr>";
                             table += "<th style='text-align: center'><input id='checkall' type='checkbox' onClick='switchSelectAll()'>";
                             table += "</th>";
@@ -515,6 +516,7 @@
                             table += "</tbody></table>"
                             $("#loader").fadeOut(500);
                             $("#mainbody").append(crumbs + table);
+                            $("#scansummary-content").tablesorter();
                             lastChecked = null;
                             var chkboxes = $('input[id*=cb_]');
                             chkboxes.click(function(e) {


### PR DESCRIPTION
Not sure if these were overlooked, or if there's a reason for these tables to not be sortable.

The only downside I see is that the checkbox column looks silly sortable, and doesn't make much sense to be sortable.

![sortable columns](https://user-images.githubusercontent.com/434827/65384370-d87c3e80-dd64-11e9-812b-a68d696f8bff.png)
