### PR TITLE
Hide stack traces unless debugging is enabled

### DIFF
--- a/sfwebui.py
+++ b/sfwebui.py
@@ -16,6 +16,7 @@ import csv
 import time
 import random
 import re
+from cherrypy import _cperror
 from operator import itemgetter
 from copy import deepcopy
 from mako.lookup import TemplateLookup
@@ -50,7 +51,8 @@ class SpiderFootWebUi:
         self.docroot = self.config['__docroot'].rstrip('/')
 
         cherrypy.config.update({
-          'error_page.404': self.error_page_404
+          'error_page.404': self.error_page_404,
+          'request.error_response': self.error_page
         })
 
         print("")
@@ -61,6 +63,14 @@ class SpiderFootWebUi:
         print("*************************************************************")
         print("")
         print("")
+
+    def error_page(self):
+        cherrypy.response.status = 500
+
+        if self.config['_debug']:
+            cherrypy.response.body = _cperror.get_error_page(status=500, traceback=_cperror.format_exc())
+        else:
+            cherrypy.response.body = '<html><body>Error</body></html>'
 
     def error_page_404(self, status, message, traceback, version):
         templ = Template(filename='dyn/error.tmpl', lookup=self.lookup)


### PR DESCRIPTION
Hide stack traces unless debugging is enabled. Returns a minimalist error page which should, in theory, not raise any additional errors unless something has gone horribly wrong.

Uses the default CherryPy `_cperror.get_error_page()` page template to format the stack trace nicely if `debug` is enabled. This is the same behaviour as prior to this PR.
