### PR TITLE
Add sf.parseEmails function to extract emails from strings

### DIFF
--- a/modules/sfp_emailformat.py
+++ b/modules/sfp_emailformat.py
@@ -67,34 +67,18 @@ class sfp_emailformat(SpiderFootPlugin):
         if res['content'] is None:
             return None
 
-        pat = re.compile("([a-zA-Z\.0-9_\-]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)")
-        matches = re.findall(pat, res['content'])
-        for match in matches:
+        emails = self.sf.parseEmails(res['content'])
+        for email in emails:
             evttype = "EMAILADDR"
-            self.sf.debug("Found possible email: " + match)
-
-            # Handle false positive matches
-            if len(match) < 5:
-                self.sf.debug("Likely invalid address.")
-                continue
-
-            if "..." in match:
-                self.sf.debug("Incomplete e-mail address, skipping.")
-                continue
-
-            # Handle messed up encodings
-            if "%" in match:
-                self.sf.debug("Skipped address: " + match)
-                continue
 
             # Skip unrelated emails
-            mailDom = match.lower().split('@')[1]
+            mailDom = email.lower().split('@')[1]
             if not self.getTarget().matches(mailDom):
-                self.sf.debug("Skipped address: " + match)
+                self.sf.debug("Skipped address: " + email)
                 continue
 
-            self.sf.info("Found e-mail address: " + match)
-            evt = SpiderFootEvent(evttype, match, self.__name__, event)
+            self.sf.info("Found e-mail address: " + email)
+            evt = SpiderFootEvent(evttype, email, self.__name__, event)
             self.notifyListeners(evt)
 
         return None

--- a/modules/sfp_pgp.py
+++ b/modules/sfp_pgp.py
@@ -81,21 +81,16 @@ class sfp_pgp(SpiderFootPlugin):
                                        useragent=self.opts['_useragent'])
 
             if res['content'] is not None:
-                pat = re.compile("([a-zA-Z\.0-9_\-]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)")
-                matches = re.findall(pat, res['content'])
-                for match in matches:
+                emails = self.sf.parseEmails(res['content'])
+                for email in emails:
                     evttype = "EMAILADDR"
-                    self.sf.debug("Found possible email: " + match)
-                    if len(match) < 4:
-                        self.sf.debug("Likely invalid address.")
-                        continue
 
-                    mailDom = match.lower().split('@')[1]
+                    mailDom = email.lower().split('@')[1]
                     if not self.getTarget().matches(mailDom):
                         evttype = "AFFILIATE_EMAILADDR"
 
-                    self.sf.info("Found e-mail address: " + match)
-                    evt = SpiderFootEvent(evttype, match, self.__name__, event)
+                    self.sf.info("Found e-mail address: " + email)
+                    evt = SpiderFootEvent(evttype, email, self.__name__, event)
                     self.notifyListeners(evt)
 
         if eventName == "EMAILADDR":

--- a/modules/sfp_skymem.py
+++ b/modules/sfp_skymem.py
@@ -67,35 +67,20 @@ class sfp_skymem(SpiderFootPlugin):
             return None
 
         # Extract emails from results page
-        pat = re.compile("([a-zA-Z\.0-9_\-]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)")
-        matches = re.findall(pat, res['content'])
-        if not matches:
-            return None
+        emails = self.sf.parseEmails(res['content'])
 
-        for match in matches:
-            self.sf.debug("Found possible email: " + match)
-
-            # Handle false positive matches
-            if len(match) < 5:
-                self.sf.debug("Likely invalid address.")
-                continue
-
-            # Handle messed up encodings
-            if "%" in match:
-                self.sf.debug("Skipped address: " + match)
-                continue
-
+        for email in emails:
             # Skip unrelated emails
-            mailDom = match.lower().split('@')[1]
+            mailDom = email.lower().split('@')[1]
             if not self.getTarget().matches(mailDom):
-                self.sf.debug("Skipped address: " + match)
+                self.sf.debug("Skipped address: " + email)
                 continue
 
-            self.sf.info("Found e-mail address: " + match)
-            if match not in self.results:
-                evt = SpiderFootEvent("EMAILADDR", match, self.__name__, event)
+            self.sf.info("Found e-mail address: " + email)
+            if emnail not in self.results:
+                evt = SpiderFootEvent("EMAILADDR", email, self.__name__, event)
                 self.notifyListeners(evt)
-                self.results[match] = True
+                self.results[email] = True
 
         # Loop through first 20 pages of results
         domain_ids = re.findall(r'<a href="/domain/([a-z0-9]+)\?p=', res['content'])
@@ -111,32 +96,19 @@ class sfp_skymem(SpiderFootPlugin):
             if res['content'] is None:
                 break
 
-            pat = re.compile("([a-zA-Z\.0-9_\-]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)")
-            matches = re.findall(pat, res['content'])
-            for match in matches:
-                self.sf.debug("Found possible email: " + match)
-
-                # Handle false positive matches
-                if len(match) < 5:
-                    self.sf.debug("Likely invalid address.")
-                    continue
-
-                # Handle messed up encodings
-                if "%" in match:
-                    self.sf.debug("Skipped address: " + match)
-                    continue
-
+            emails = self.sf.parseEmails(res['content'])
+            for email in emails:
                 # Skip unrelated emails
-                mailDom = match.lower().split('@')[1]
+                mailDom = email.lower().split('@')[1]
                 if not self.getTarget().matches(mailDom):
-                    self.sf.debug("Skipped address: " + match)
+                    self.sf.debug("Skipped address: " + email)
                     continue
 
-                self.sf.info("Found e-mail address: " + match)
-                if match not in self.results:
-                    evt = SpiderFootEvent("EMAILADDR", match, self.__name__, event)
+                self.sf.info("Found e-mail address: " + email)
+                if email not in self.results:
+                    evt = SpiderFootEvent("EMAILADDR", email, self.__name__, event)
                     self.notifyListeners(evt)
-                    self.results[match] = True
+                    self.results[email] = True
 
             # Check if we're on the last page of results
             max_page = 0

--- a/modules/sfp_skymem.py
+++ b/modules/sfp_skymem.py
@@ -77,7 +77,7 @@ class sfp_skymem(SpiderFootPlugin):
                 continue
 
             self.sf.info("Found e-mail address: " + email)
-            if emnail not in self.results:
+            if email not in self.results:
                 evt = SpiderFootEvent("EMAILADDR", email, self.__name__, event)
                 self.notifyListeners(evt)
                 self.results[email] = True

--- a/sflib.py
+++ b/sflib.py
@@ -889,6 +889,34 @@ class SpiderFoot:
 
         return returnArr
 
+    # Find all emails within the supplied content
+    # Returns an Array
+    def parseEmails(self, data):
+        emails = list()
+        matches = re.findall(r'([\%a-zA-Z\.0-9_\-\+]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)', str(data).decode('unicode-escape'))
+
+        for match in matches:
+            self.debug("Found possible email: " + match)
+
+            # Handle false positive matches
+            if len(match) < 5:
+                self.debug("Skipped likely invalid email address.")
+                continue
+
+            # Handle messed up encodings
+            if "%" in match:
+                self.debug("Skipped invalid email address: " + match)
+                continue
+
+            # Handle truncated emails
+            if "..." in match:
+                self.debug("Skipped incomplete e-mail address: " + match)
+                continue
+
+            emails.append(match)
+
+        return set(emails)
+
     # Find all URLs within the supplied content. This does not fetch any URLs!
     # A dictionary will be returned, where each link will have the keys
     # 'source': The URL where the link was obtained from

--- a/sflib.py
+++ b/sflib.py
@@ -893,7 +893,7 @@ class SpiderFoot:
     # Returns an Array
     def parseEmails(self, data):
         emails = list()
-        matches = re.findall(r'([\%a-zA-Z\.0-9_\-\+]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)', str(data).decode('unicode-escape'))
+        matches = re.findall(r'([\%a-zA-Z\.0-9_\-\+]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)', data)
 
         for match in matches:
             self.debug("Found possible email: " + match)


### PR DESCRIPTION
This PR abstracts email regex parsing into a separate `sf.parseEmails()` function in `sflib`, which operates in a similar fashion to `sf.parseLinks()`.

This decreases repetition, decreases lines of code, and consolidates functionality such that future parsing enhancements are easier. For example, in the future we may want to add functionality for fuzzy matching, which matches strings such as `recipient<at>domain<dot>tld`, `recipient(at)domain.tld`, etc.

This also has the added advantage that, in the future, modules can simple shove data into this function and see what falls out.

I've done some light testing to ensure the modules don't throw an error, but I haven't tested this PR thoroughly.