### PR TITLE
Use getTarget() includeChildren=True, includeParents=True for emails

### DIFF
--- a/modules/sfp_email.py
+++ b/modules/sfp_email.py
@@ -66,7 +66,7 @@ class sfp_email(SpiderFootPlugin):
 
             # Get the domain and strip potential ending .
             mailDom = email.lower().split('@')[1].strip('.')
-            if not self.getTarget().matches(mailDom) and not self.getTarget().matches(match):
+            if not self.getTarget().matches(mailDom, includeChildren=True, includeParents=True) and not self.getTarget().matches(match):
                 self.sf.debug("External domain, so possible affiliate e-mail")
                 evttype = "AFFILIATE_EMAILADDR"
 

--- a/modules/sfp_emailformat.py
+++ b/modules/sfp_emailformat.py
@@ -31,7 +31,6 @@ class sfp_emailformat(SpiderFootPlugin):
 
     def setup(self, sfc, userOpts=dict()):
         self.sf = sfc
-        self.__dataSource__ = "Email-Format.com"
         self.results = self.tempStorage()
 
         for opt in userOpts.keys():
@@ -39,7 +38,7 @@ class sfp_emailformat(SpiderFootPlugin):
 
     # What events is this module interested in for input
     def watchedEvents(self):
-        return ["DOMAIN_NAME"]
+        return ['INTERNET_NAME', "DOMAIN_NAME"]
 
     # What events this module produces
     # This is to support the end user in selecting modules based on events
@@ -73,7 +72,7 @@ class sfp_emailformat(SpiderFootPlugin):
 
             # Skip unrelated emails
             mailDom = email.lower().split('@')[1]
-            if not self.getTarget().matches(mailDom):
+            if not self.getTarget().matches(mailDom, includeChildren=True, includeParents=True):
                 self.sf.debug("Skipped address: " + email)
                 continue
 

--- a/modules/sfp_pgp.py
+++ b/modules/sfp_pgp.py
@@ -48,7 +48,7 @@ class sfp_pgp(SpiderFootPlugin):
 
     # What events is this module interested in for input
     def watchedEvents(self):
-        return ["EMAILADDR", "DOMAIN_NAME"]
+        return ['INTERNET_NAME', "EMAILADDR", "DOMAIN_NAME"]
 
     # What events this module produces
     # This is to support the end user in selecting modules based on events
@@ -86,7 +86,7 @@ class sfp_pgp(SpiderFootPlugin):
                     evttype = "EMAILADDR"
 
                     mailDom = email.lower().split('@')[1]
-                    if not self.getTarget().matches(mailDom):
+                    if not self.getTarget().matches(mailDom, includeChildren=True, includeParents=True):
                         evttype = "AFFILIATE_EMAILADDR"
 
                     self.sf.info("Found e-mail address: " + email)

--- a/modules/sfp_skymem.py
+++ b/modules/sfp_skymem.py
@@ -38,7 +38,7 @@ class sfp_skymem(SpiderFootPlugin):
 
     # What events is this module interested in for input
     def watchedEvents(self):
-        return ["DOMAIN_NAME"]
+        return ['INTERNET_NAME', "DOMAIN_NAME"]
 
     # What events this module produces
     # This is to support the end user in selecting modules based on events
@@ -71,7 +71,7 @@ class sfp_skymem(SpiderFootPlugin):
         for email in emails:
             # Skip unrelated emails
             mailDom = email.lower().split('@')[1]
-            if not self.getTarget().matches(mailDom):
+            if not self.getTarget().matches(mailDom, includeChildren=True, includeParents=True):
                 self.sf.debug("Skipped address: " + email)
                 continue
 
@@ -99,7 +99,7 @@ class sfp_skymem(SpiderFootPlugin):
             for email in emails:
                 # Skip unrelated emails
                 mailDom = email.lower().split('@')[1]
-                if not self.getTarget().matches(mailDom):
+                if not self.getTarget().matches(mailDom, includeChildren=True, includeParents=True):
                     self.sf.debug("Skipped address: " + email)
                     continue
 


### PR DESCRIPTION
Make use of `getTarget()` `includeChildren=True`, `includeParents=True` for emails

Also updates the `fp_flickr` module to make use of the new `parseEmails()` function.

Also updates the email modules to accept both `INTERNET_NAME` and `DOMAIN_NAME` as `watchedEvents`, instead of only `DOMAIN_NAME`.
