### PR TITLE
Validate IP_ADDRESS and IPV6_ADDRESS events

### DIFF
--- a/modules/sfp_fsecure_riddler.py
+++ b/modules/sfp_fsecure_riddler.py
@@ -208,8 +208,9 @@ class sfp_fsecure_riddler(SpiderFootPlugin):
             self.notifyListeners(evt)
 
         for addr in set(addrs):
-            evt = SpiderFootEvent('IP_ADDRESS', addr, self.__name__, event)
-            self.notifyListeners(evt)
+            if self.sf.validIP(addr):
+                evt = SpiderFootEvent('IP_ADDRESS', addr, self.__name__, event)
+                self.notifyListeners(evt)
 
         for coord in set(coords):
             evt = SpiderFootEvent('PHYSICAL_COORDINATES', coord, self.__name__, event)

--- a/modules/sfp_mnemonic.py
+++ b/modules/sfp_mnemonic.py
@@ -145,12 +145,14 @@ class sfp_mnemonic(SpiderFootPlugin):
                     continue
 
                 if r['rrtype'] == 'a':
-                    evt = SpiderFootEvent("IP_ADDRESS", r['answer'], self.__name__, event)
-                    self.notifyListeners(evt)
+                    if self.sf.validIP(r['answer']):
+                        evt = SpiderFootEvent("IP_ADDRESS", r['answer'], self.__name__, event)
+                        self.notifyListeners(evt)
 
                 if r['rrtype'] == 'aaaa':
-                    evt = SpiderFootEvent("IPV6_ADDRESS", r['answer'], self.__name__, event)
-                    self.notifyListeners(evt)
+                    if self.sf.validIP6(r['answer']):
+                        evt = SpiderFootEvent("IPV6_ADDRESS", r['answer'], self.__name__, event)
+                        self.notifyListeners(evt)
 
                 if r['rrtype'] == 'cname':
                     if not self.getTarget().matches(r['query'], includeParents=True):

--- a/modules/sfp_ssltools.py
+++ b/modules/sfp_ssltools.py
@@ -122,8 +122,9 @@ class sfp_ssltools(SpiderFootPlugin):
         addresses = data.get('addresses')
 
         for address in addresses:
-            evt = SpiderFootEvent('IP_ADDRESS', address, self.__name__, event)
-            self.notifyListeners(evt)
+            if self.sf.validIP(address):
+                evt = SpiderFootEvent('IP_ADDRESS', address, self.__name__, event)
+                self.notifyListeners(evt)
 
         port = 443
         data = self.queryScan(eventData, port)


### PR DESCRIPTION
Validate `IP_ADDRESS` and `IPV6_ADDRESS` events.

Requires #399 for `validIP6()` function.
