### PR TITLE
Skip SPF domains containing underscore

### DIFF
--- a/modules/sfp_dnsraw.py
+++ b/modules/sfp_dnsraw.py
@@ -124,7 +124,9 @@ class sfp_dnsraw(SpiderFootPlugin):
                                 matches = re.findall(r'include:(.+?) ', strdata, re.IGNORECASE | re.DOTALL)
                                 if matches:
                                     for domain in matches:
-                                        if self.getTarget().matches(domain, includeChildren=True):
+                                        if '_' in domain:
+                                            continue
+                                        if self.getTarget().matches(domain, includeChildren=True, includeParents=True):
                                             evt_type = 'INTERNET_NAME'
                                         else:
                                             evt_type = 'AFFILIATE_DOMAIN'


### PR DESCRIPTION
Skip SPF domains containing underscore. It is common for SPF records to contain a `_spf.domain.tld` record.

Also adds `includeParents=True` for `getTarget()`.
