### PR TITLE
Update sfp_mnemonic

### DIFF
--- a/modules/sfp_mnemonic.py
+++ b/modules/sfp_mnemonic.py
@@ -49,6 +49,7 @@ class sfp_mnemonic(SpiderFootPlugin):
         self.sf = sfc
         self.results = self.tempStorage()
         self.cohostcount = 0                                                                                                                                                                                       
+        self.errorState = False
 
         for opt in userOpts.keys():
             self.opts[opt] = userOpts[opt]

--- a/modules/sfp_mnemonic.py
+++ b/modules/sfp_mnemonic.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # -------------------------------------------------------------------------------
-# Name:         sfp_mnemonic
-# Purpose:      SpiderFoot plug-in for retrieving passive DNS information
-#               from Mnemonic PassiveDNS API.
+# Name:        sfp_mnemonic
+# Purpose:     SpiderFoot plug-in for retrieving passive DNS information
+#              from Mnemonic PassiveDNS API.
 #
 # Author:      <bcoles@gmail.com>
 #
@@ -13,6 +13,7 @@
 
 import json
 import time
+import urllib
 from sflib import SpiderFoot, SpiderFootPlugin, SpiderFootEvent
 
 class sfp_mnemonic(SpiderFootPlugin):
@@ -20,9 +21,10 @@ class sfp_mnemonic(SpiderFootPlugin):
 
     # Default options
     opts = {
-        'limit': 1000,
+        'per_page': 500,
+        'max_pages': 2,
         'timeout': 30,
-        'maxage': 1095,   # 3 years
+        'maxage': 180,    # 6 months
         'verify': True,
         'cohostsamedomain': False,
         'maxcohost': 100
@@ -30,7 +32,8 @@ class sfp_mnemonic(SpiderFootPlugin):
 
     # Option descriptions
     optdescs = {
-        'limit': "Maximum number of results to fetch.",
+        'per_page': "Maximum number of results per page.",
+        'max_pages': "Maximum number of pages of results to fetch.",
         'timeout': "Query timeout, in seconds.",
         'maxage': "The maximum age of the data returned, in days, in order to be considered valid.",
         'verify': "Verify co-hosts are valid by checking if they still resolve to the shared IP.",
@@ -40,30 +43,38 @@ class sfp_mnemonic(SpiderFootPlugin):
 
     cohostcount = 0
     results = None
+    errorState = False
 
     def setup(self, sfc, userOpts=dict()):
         self.sf = sfc
-        self.__dataSource__ = "Mnemonic PassiveDNS"
         self.results = self.tempStorage()
         self.cohostcount = 0                                                                                                                                                                                       
+
         for opt in userOpts.keys():
             self.opts[opt] = userOpts[opt]
 
     # What events is this module interested in for input
     def watchedEvents(self):
-        return ['IP_ADDRESS', 'INTERNET_NAME', 'DOMAIN_NAME']
+        return ['IP_ADDRESS', 'IPV6_ADDRESS', 'INTERNET_NAME', 'DOMAIN_NAME']
 
     # What events this module produces
     def producedEvents(self):
-        return ['IP_ADDRESS', 'IPV6_ADDRESS', 'CO_HOSTED_SITE', 
+        return ['IP_ADDRESS', 'IPV6_ADDRESS', 'CO_HOSTED_SITE',
                 'INTERNET_NAME', 'DOMAIN_NAME']
 
-    # Query the PassiveDNS Mnemonic REST API
-    def query(self, qry, limit=1000, offset=0):
-        url = "https://api.mnemonic.no/pdns/v3/" + qry
-        url += "?limit=" + str(limit) + "&offset=" + str(offset)
+    # Query the Mnemonic PassiveDNS v3 API
+    # https://docs.mnemonic.no/display/public/API/PassiveDNS+Integration+Guide
+    def query(self, qry, limit=500, offset=0):
+        params = {
+            'limit': str(limit),
+            'offset': str(offset)
+        }
 
+        url = 'https://api.mnemonic.no/pdns/v3/' + qry + '?' + urllib.urlencode(params)
         res = self.sf.fetchUrl(url, timeout=self.opts['timeout'], useragent=self.opts['_useragent'])
+
+        # Unauthenticated users are limited to 100 requests per minute, and 1000 requests per day.
+        time.sleep(0.75)
 
         if res['content'] is None:
             self.sf.info("No results found for " + qry)
@@ -77,6 +88,11 @@ class sfp_mnemonic(SpiderFootPlugin):
             return None
 
         # Check the response is ok
+        if data['responseCode'] == 402:
+            self.sf.debug("Error retrieving search results: Resource limit exceeded")
+            self.errorState = True
+            return None
+
         if not data['responseCode'] == 200:
             self.sf.debug("Error retrieving search results.")
             return None
@@ -111,64 +127,82 @@ class sfp_mnemonic(SpiderFootPlugin):
         srcModuleName = event.module
         eventData = event.data
 
-        if eventData in self.results:
+        if self.errorState:
             return None
-        else:
-            self.results[eventData] = True
+
+        if eventData in self.results:
+            self.sf.debug("Skipping " + eventData + " as already mapped.")
+            return None
+
+        self.results[eventData] = True
 
         self.sf.debug("Received event, " + eventName + ", from " + srcModuleName)
 
-        # Query Mnemonic PassiveDNS API
-        data = self.query(eventData, limit=self.opts['limit'], offset=0)
-
-        if data is None:
-            self.sf.info("No passive DNS data found for " + eventData)
-            return None
-
+        position = 0
+        max_pages = int(self.opts['max_pages'])
+        per_page = int(self.opts['per_page'])
         agelimit = int(time.time() * 1000) - (86400000 * self.opts['maxage'])
         cohostcount = 0                                                                                                                                                                                                
         cohosts = list()                                                                                                                                                                                       
 
-        for r in data:
-            if r['lastSeenTimestamp'] < agelimit:
-                self.sf.debug("Record found too old, skipping.")
-                continue
+        while position < (per_page * max_pages):
+            if self.checkForStop():
+                break
 
-            if eventName in [ 'IP_ADDRESS' ]:
-                if r['rrtype'] == 'a':
-                    cohosts.append(r['query'])
+            if self.errorState:
+                break
 
-            if eventName in [ 'INTERNET_NAME', 'DOMAIN_NAME' ]:
+            data = self.query(eventData, limit=per_page, offset=position)
 
-                # Ignore PTR records
-                if r['rrtype'] == 'ptr':
+            if data is None:
+                self.sf.info("No passive DNS data found for " + eventData)
+                break
+
+            position += per_page
+
+            for r in data:
+                if "*" in r['query'] or "%" in r['query']:
                     continue
 
-                if r['rrtype'] == 'a':
-                    if self.sf.validIP(r['answer']):
-                        evt = SpiderFootEvent("IP_ADDRESS", r['answer'], self.__name__, event)
-                        self.notifyListeners(evt)
+                if r['lastSeenTimestamp'] < agelimit:
+                    self.sf.debug("Record found too old, skipping.")
+                    continue
 
-                if r['rrtype'] == 'aaaa':
-                    if self.sf.validIP6(r['answer']):
-                        evt = SpiderFootEvent("IPV6_ADDRESS", r['answer'], self.__name__, event)
-                        self.notifyListeners(evt)
+                if eventName in [ 'IP_ADDRESS' ]:
+                    if r['rrtype'] == 'a':
+                        cohosts.append(r['query'])
 
-                if r['rrtype'] == 'cname':
-                    if not self.getTarget().matches(r['query'], includeParents=True):
+                if eventName in [ 'INTERNET_NAME', 'DOMAIN_NAME' ]:
+
+                    # Ignore PTR records
+                    if r['rrtype'] == 'ptr':
                         continue
 
-                    if "*" in r['query'] or "%" in r['query']:
-                        continue
+                    if r['rrtype'] == 'a':
+                        if self.sf.validIP(r['answer']):
+                            evt = SpiderFootEvent("IP_ADDRESS", r['answer'], self.__name__, event)
+                            self.notifyListeners(evt)
 
-                    cohosts.append(r['query'])
+                    if r['rrtype'] == 'aaaa':
+                        if self.sf.validIP6(r['answer']):
+                            evt = SpiderFootEvent("IPV6_ADDRESS", r['answer'], self.__name__, event)
+                            self.notifyListeners(evt)
 
-        for co in cohosts:
-            if eventName == "IP_ADDRESS" and (self.opts['verify'] and not self.sf.validateIP(co, eventData)):
-                self.sf.debug("Host " + co + " no longer resolves to " + eventData)
-                continue
+                    if r['rrtype'] == 'cname':
+                        if not self.getTarget().matches(r['query'], includeParents=True):
+                            continue
+
+                        cohosts.append(r['query'])
+
+        for co in set(cohosts):
+            if self.checkForStop():
+                return None
 
             if co in self.results:
+                continue
+
+            if eventName == "IP_ADDRESS" and (self.opts['verify'] and not self.sf.validateIP(co, eventData)):
+                self.sf.debug("Host " + co + " no longer resolves to " + eventData)
                 continue
 
             if not self.opts['cohostsamedomain']:


### PR DESCRIPTION
* Decrease `maxage` to `180` (from `1095`) to decrease false positives and significantly decrease runtime.
* Use pagination to decrease the risk of request timeouts.
* Add support for `errorState` when the API returns `resource limit exceeded`.
* Add support for `checkForStop()`.
* Apply `if "*" in r['query'] or "%" in r['query']` sanity check validation to the results of all watched event types
