### PR TITLE
Add missing dependency for building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY requirements.txt .
 
 # Run everything as one command so that only one layer is created
 RUN apk --update add --no-cache --virtual build-dependencies gcc git curl py2-pip swig \
-        tinyxml-dev python2-dev musl-dev openssl-dev libxslt-dev \
+        tinyxml-dev python2-dev musl-dev openssl-dev libffi-dev libxslt-dev \
     && apk --update --no-cache add python2 musl openssl libxslt tinyxml \
     && pip --no-cache-dir install wheel \
     && pip --no-cache-dir install -r requirements.txt \


### PR DESCRIPTION
Building the docker image results in an error (see below). I've added a dependency for `libffi-dev` to make sure building the `cffi` Python package succeeds.

```
[...]
  Failed to build cffi
  Installing collected packages: setuptools, wheel, pycparser, cffi
    Running setup.py install for cffi: started
      Running setup.py install for cffi: finished with status 'error'
      Complete output from command /usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-QI6b9d/cffi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-Rn5Dfb/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-94Dj3e --compile:
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      Package libffi was not found in the pkg-config search path.
      Perhaps you should add the directory containing `libffi.pc'
      to the PKG_CONFIG_PATH environment variable
      Package 'libffi', required by 'virtual:world', not found
      running install
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-2.7
      creating build/lib.linux-x86_64-2.7/cffi
      copying cffi/commontypes.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/lock.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/ffiplatform.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/error.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/recompiler.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/api.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/cffi_opcode.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/vengine_cpy.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/vengine_gen.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/__init__.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/setuptools_ext.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/pkgconfig.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/model.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/cparser.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/verifier.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/backend_ctypes.py -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/_cffi_include.h -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/parse_c_type.h -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/_embedding.h -> build/lib.linux-x86_64-2.7/cffi
      copying cffi/_cffi_errors.h -> build/lib.linux-x86_64-2.7/cffi
      running build_ext
      building '_cffi_backend' extension
      creating build/temp.linux-x86_64-2.7
      creating build/temp.linux-x86_64-2.7/c
      gcc -fno-strict-aliasing -Os -fomit-frame-pointer -g -DNDEBUG -Os -fomit-frame-pointer -g -DTHREAD_STACK_SIZE=0x100000 -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python2.7 -c c/_cffi_backend.c -o build/temp.linux-x86_64-2.7/c/_cffi_backend.o
      c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
       #include <ffi.h>
                ^~~~~~~
      compilation terminated.
      error: command 'gcc' failed with exit status 1
  
      ----------------------------------------
  Command "/usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-QI6b9d/cffi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-Rn5Dfb/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-94Dj3e --compile" failed with error code 1 in /tmp/pip-install-QI6b9d/cffi/
  
  ----------------------------------------
Command "/usr/bin/python2 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-94Dj3e --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools>=40.6.0 wheel "cffi>=1.8,!=1.11.3; python_implementation != 'PyPy'"" failed with error code 1 in None
The command '/bin/sh -c apk --update add --no-cache --virtual build-dependencies gcc git curl py2-pip swig         tinyxml-dev python2-dev musl-dev openssl-dev libxslt-dev     && apk --update --no-cache add python2 musl openssl libxslt tinyxml     && pip --no-cache-dir install wheel     && pip --no-cache-dir install -r requirements.txt     && addgroup spiderfoot     && adduser -G spiderfoot -h /home/spiderfoot -s /sbin/nologin                -g "SpiderFoot User" -D spiderfoot     && rmdir /home/spiderfoot     && cd /home     && curl -sSL https://github.com/smicallef/spiderfoot/archive/master.tar.gz        | tar -v -C /home -xz     && mv /home/spiderfoot-master /home/spiderfoot     && chown -R spiderfoot:spiderfoot /home/spiderfoot     && apk del --purge build-dependencies     && rm -rf /var/cache/apk/*     && rm -rf /root/.cache' returned a non-zero code: 1
```