### PR TITLE
Print number of domains pending DNS resolution

### DIFF
--- a/modules/sfp_crt.py
+++ b/modules/sfp_crt.py
@@ -100,6 +100,9 @@ class sfp_crt(SpiderFootPlugin):
             if domain and domain != eventData:
                 domains.append(domain.replace("*.", ""))
 
+        if self.opts['verify'] and len(domains) > 0:
+            self.sf.info("Resolving " + str(len(set(domains))) + " domains ...")
+
         for domain in set(domains):
             if domain in self.results:
                 continue

--- a/modules/sfp_fsecure_riddler.py
+++ b/modules/sfp_fsecure_riddler.py
@@ -195,6 +195,9 @@ class sfp_fsecure_riddler(SpiderFootPlugin):
             if coord and len(coord) == 2:
                 coords.append(str(coord[0]) + ', ' + str(coord[1]))
 
+        if self.opts['verify'] and len(hosts) > 0:
+            self.sf.info("Resolving " + str(len(set(hosts))) + " domains ...")
+
         for host in set(hosts):
             if self.getTarget().matches(host, includeChildren=True, includeParents=True):
                 evt_type = 'INTERNET_NAME'
@@ -207,6 +210,7 @@ class sfp_fsecure_riddler(SpiderFootPlugin):
 
             evt = SpiderFootEvent(evt_type, host, self.__name__, event)
             self.notifyListeners(evt)
+
             if not evt_type.startswith('AFFILIATE') and self.sf.isDomain(host, self.opts['_internettlds']):
                 evt = SpiderFootEvent('DOMAIN_NAME', host, self.__name__, event)
                 self.notifyListeners(evt)

--- a/modules/sfp_urlscan.py
+++ b/modules/sfp_urlscan.py
@@ -159,6 +159,9 @@ class sfp_urlscan(SpiderFootPlugin):
             evt = SpiderFootEvent('GEOINFO', location, self.__name__, event)
             self.notifyListeners(evt)
 
+        if self.opts['verify'] and len(domains) > 0:
+            self.sf.info("Resolving " + str(len(set(domains))) + " domains ...")
+
         for domain in set(domains):
             if self.opts['verify'] and not self.sf.resolveHost(domain):
                 evt = SpiderFootEvent('INTERNET_NAME_UNRESOLVED', domain, self.__name__, event)


### PR DESCRIPTION
Print number of domains pending DNS resolution.

Often, when modules produce a large number of results, a large number of domains are collected during initial parsing, which results in a lot of DNS queries. This PR prints a message so there's some visibility into how many domains are to be resolved.