### PR TITLE
Silence bandit warnings in sfcli

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -1046,7 +1046,7 @@ class SpiderFootCli(cmd.Cmd):
             return
         j = list()
         serverconfig = dict()
-        token = ""
+        token = "" # nosec
         if not d:
             self.edprint("Unable to obtain SpiderFoot server-side config.")
         else:
@@ -1161,7 +1161,7 @@ class SpiderFootCli(cmd.Cmd):
         """shell
         Run a shell command locally."""
         self.dprint("Running shell command:" + str(line))
-        self.dprint(os.popen(line).read(), plain=True)
+        self.dprint(os.popen(line).read(), plain=True) # nosec
 
     def do_clear(self, line):
         """clear


### PR DESCRIPTION
`token = ""` is not a password.

`os.popen` is used by the `shell` CLI command to execute shell commands locally. This is expected.

```
# python2.7 -m bandit sfcli.py
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	running on Python 2.7.16
[node_visitor]	INFO	Unable to find qualified name for module: sfcli.py
Run started:2019-10-20 09:01:43.183268

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 1036
	Total lines skipped (#nosec): 2

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```
