### PR TITLE
Use securepy - Fix #386

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ PyPDF2>=1.26.0
 stem>=1.7.1
 python-whois>=0.7.1
 future
+secure
 pyOpenSSL>=16.2.0
 python-docx>=0.8.10
 python-pptx>=0.6.18

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -15,6 +15,7 @@ import cgi
 import csv
 import time
 import random
+from secure import SecureHeaders
 from cherrypy import _cperror
 from operator import itemgetter
 from copy import deepcopy
@@ -52,6 +53,13 @@ class SpiderFootWebUi:
         cherrypy.config.update({
           'error_page.404': self.error_page_404,
           'request.error_response': self.error_page
+        })
+
+        secure_headers = SecureHeaders()
+
+        cherrypy.config.update({
+            "tools.response_headers.on": True,
+            "tools.response_headers.headers": secure_headers.cherrypy()
         })
 
         print("")


### PR DESCRIPTION
https://secure.readthedocs.io/en/latest/frameworks.html#cherrypy

```
$ curl -isk http://127.0.0.1:5001 -X HEAD
HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8
Server: CherryPy/18.3.0
Date: Sun, 17 Nov 2019 04:01:40 GMT
Strict-Transport-Security: max-age=63072000; includeSubdomains
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Referrer-Policy: no-referrer, strict-origin-when-cross-origin
Pragma: no-cache
Expires: 0
Cache-Control: no-cache, no-store, must-revalidate, max-age=0
Content-Length: 16657

```
