### PR TITLE
sfcli - Fix syntax error

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -1134,7 +1134,7 @@ class SpiderFootCli(cmd.Cmd):
                         confdata[optstr] = ','.join(serverconfig[k])
                     if type(serverconfig[k]) == int:
                         confdata[optstr] = str(serverconfig[k])
-                    if type(serverconfig[k]) in == str:
+                    if type(serverconfig[k]) == str:
                         confdata[optstr] = serverconfig[k]
     
                 self.ddprint(str(confdata))


### PR DESCRIPTION
```
$ ./sfcli.py 
  File "./sfcli.py", line 1137
    if type(serverconfig[k]) in == str:
                                 ^
SyntaxError: invalid syntax
```