### PR TITLE
Fix integer brute force

### DIFF
--- a/modules/sfp_dnsbrute.py
+++ b/modules/sfp_dnsbrute.py
@@ -165,7 +165,7 @@ class sfp_dnsbrute(SpiderFootPlugin):
 
             dom = "." + dom
             nextsubs = dict()
-            for i in range(0, 9):
+            for i in range(10):
                 nextsubs[h + str(i) + dom] = True
                 nextsubs[h + "0" + str(i) + dom] = True
                 nextsubs[h + "00" + str(i) + dom] = True
@@ -213,7 +213,7 @@ class sfp_dnsbrute(SpiderFootPlugin):
                 if self.checkForStop():
                     return None
 
-                for i in range(0, 9):
+                for i in range(10):
                     nextsubs[s + str(i) + dom] = True
                     nextsubs[s + "0" + str(i) + dom] = True
                     nextsubs[s + "00" + str(i) + dom] = True


### PR DESCRIPTION
I haven't tested this, but I'm pretty sure for integer brute forcing for single digits, you want 0-9 not 0-8.

```
$ python
Python 2.7.17 (default, Oct 19 2019, 23:36:22) 
[GCC 9.2.1 20191008] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> for i in range(0, 9):
...   print(str(i))
... 
0
1
2
3
4
5
6
7
8
>>> for i in range(9):
...   print(str(i))
... 
0
1
2
3
4
5
6
7
8
>>> for i in range(10):
...   print(str(i))
... 
0
1
2
3
4
5
6
7
8
9
>>> 
```

```
$ python3
Python 3.7.5 (default, Oct 27 2019, 15:43:29) 
[GCC 9.2.1 20191022] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> for i in range(0, 9):
...   print(str(i))
... 
0
1
2
3
4
5
6
7
8
>>> for i in range(9):
...   print(str(i))
... 
0
1
2
3
4
5
6
7
8
>>> for i in range(10):
...   print(str(i))
... 
0
1
2
3
4
5
6
7
8
9
>>> 
```
