### PR TITLE
Update Unit Tests

### DIFF
--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -54,8 +54,8 @@ class TestSpiderFoot(unittest.TestCase):
         """
         sf = SpiderFoot(dict())
 
-        sf.updateSocket(None)
-        self.assertEqual('TBD', 'TBD')
+        sf.updateSocket('new socket')
+        self.assertEqual('new socket', sf.socksProxy)
 
     def test_revert_socket(self):
         """
@@ -64,16 +64,16 @@ class TestSpiderFoot(unittest.TestCase):
         sf = SpiderFoot(dict())
 
         sf.revertSocket()
-        self.assertEqual('TBD', 'TBD')
+        self.assertEqual(None, sf.socksProxy)
 
-    def test_refresh_tor_ident(self):
+    def test_refresh_tor_ident_should_return_none(self):
         """
         Test refreshTorIdent(self)
         """
-        sf = SpiderFoot(dict())
+        sf = SpiderFoot(self.default_options)
 
-        sf.refreshTorIdent()
-        self.assertEqual('TBD', 'TBD')
+        res = sf.refreshTorIdent()
+        self.assertEqual(None, res)
 
     def test_opt_value_to_data(self):
         """
@@ -124,13 +124,19 @@ class TestSpiderFoot(unittest.TestCase):
         """
         Test setDbh(self, handle)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(dict())
+
+        sf.setDbh('new handle')
+        self.assertEqual('new handle', sf.dbh)
 
     def test_set_guid(self):
         """
         Test setGUID(self, uid)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(dict())
+
+        sf.setGUID('new guid')
+        self.assertEqual('new guid', sf.GUID)
 
     def test_gen_scan_instance_guid_should_return_a_string(self):
         """
@@ -156,14 +162,16 @@ class TestSpiderFoot(unittest.TestCase):
         sf.error(None)
         self.assertEqual('TBD', 'TBD')
 
-    def test_fatal(self):
+    def test_fatal_should_exit(self):
         """
         Test fatal(self, error)
         """
         sf = SpiderFoot(self.default_options)
 
-        sf.fatal(None)
-        self.assertEqual('TBD', 'TBD')
+        with self.assertRaises(SystemExit) as cm:
+            sf.fatal(None)
+
+        self.assertEqual(cm.exception.code, -1)
 
     def test_status(self):
         """
@@ -192,7 +200,7 @@ class TestSpiderFoot(unittest.TestCase):
         sf.debug(None)
         self.assertEqual('TBD', 'TBD')
 
-    def test_my_path_should_return_a_str(self):
+    def test_my_path_should_return_a_string(self):
         """
         Test myPath(self)
         """
@@ -225,29 +233,32 @@ class TestSpiderFoot(unittest.TestCase):
         """
         self.assertEqual('TBD', 'TBD')
 
-    def test_cache_get(self):
-        """
-        Test cacheGet(self, label, timeoutHrs)
-        """
-        self.assertEqual('TBD', 'TBD')
-
-    def test_cache_get_invalid_label(self):
+    def test_cache_get_should_return_a_string(self):
         """
         Test cacheGet(self, label, timeoutHrs)
         """
         sf = SpiderFoot(dict())
 
-        cache_get = sf.cacheGet(None, None)
-        self.assertEqual('TBD', 'TBD')
+        cache_get = sf.cacheGet('', sf.opts.get('cacheperiod', 0))
+        self.assertEqual(str, type(cache_get))
 
-    def test_cache_get_invalid_timeout(self):
+    def test_cache_get_invalid_label_should_return_none(self):
+        """
+        Test cacheGet(self, label, timeoutHrs)
+        """
+        sf = SpiderFoot(dict())
+
+        cache_get = sf.cacheGet(None, sf.opts.get('cacheperiod', 0))
+        self.assertEqual(None, cache_get)
+
+    def test_cache_get_invalid_timeout_should_return_none(self):
         """
         Test cacheGet(self, label, timeoutHrs)
         """
         sf = SpiderFoot(dict())
 
         cache_get = sf.cacheGet('', None)
-        self.assertEqual('TBD', 'TBD')
+        self.assertEqual(None, cache_get)
 
     def test_config_serialize(self):
         """
@@ -339,35 +350,50 @@ class TestSpiderFoot(unittest.TestCase):
         """
         self.assertEqual('TBD', 'TBD')
 
-    def test_host_domain(self):
+    def test_host_domain_should_return_a_boolean(self):
         """
         Test hostDomain(self, hostname, tldList)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(dict())
 
-    def test_is_domain(self):
+        host_doman = sf.hostDomain('local', None)
+        self.assertEqual(bool, type(host_domain))
+
+    def test_is_domain_should_return_a_boolean(self):
         """
         Test isDomain(self, hostname, tldList)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(dict())
 
-    def test_valid_ip(self):
+        is_domain = sf.isDomain('local', None)
+        self.assertEqual(bool, type(is_domain))
+
+    def test_valid_ip_should_return_a_boolean(self):
         """
         Test validIP(self, address)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(dict())
 
-    def test_valid_ip6(self):
+        valid_ip = sf.validIP('0.0.0.0')
+        self.assertEqual(bool, type(valid_ip))
+
+    def test_valid_ip6_should_return_a_boolean(self):
         """
         Test validIP6(self, address)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(dict())
 
-    def test_valid_ip_network(self):
+        valid_ip6 = sf.validIP6('::1')
+        self.assertEqual(bool, type(valid_ip6))
+
+    def test_valid_ip_network_should_return_a_boolean(self):
         """
         Test validIpNetwork(self, cidr)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(dict())
+
+        valid_ip_network = sf.validIpNetwork('0.0.0.0/0')
+        self.assertEqual(bool, type(valid_ip_network))
 
     def tes_normalize_dns(self):
         """
@@ -471,17 +497,50 @@ class TestSpiderFoot(unittest.TestCase):
         """
         self.assertEqual('TBD', 'TBD')
 
-    def test_parse_links(self):
+    def test_parse_links_should_return_a_dict(self):
         """
-        Test parseLinks(self, url, data, domains, parseText=True)
+        Test parseLinks(self, url, data, domains)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(self.default_options)
 
-    def test_url_encode_unicode(self):
+        parse_links = sf.parseLinks('url', 'data', 'domains')
+        self.assertEqual(dict, type(parse_links))
+
+    def test_parse_links_invalid_url_should_return_a_dict(self):
+        """
+        Test parseLinks(self, url, data, domains)
+        """
+        sf = SpiderFoot(self.default_options)
+
+        parse_links = sf.parseLinks(None, 'data', 'domains')
+        self.assertEqual(dict, type(parse_links))
+
+    def test_parse_links_invalid_data_should_return_a_dict(self):
+        """
+        Test parseLinks(self, url, data, domains)
+        """
+        sf = SpiderFoot(self.default_options)
+
+        parse_links = sf.parseLinks('url', None, 'domains')
+        self.assertEqual(dict, type(parse_links))
+
+    def test_parse_links_invalid_domains_should_return_a_dict(self):
+        """
+        Test parseLinks(self, url, data, domains)
+        """
+        sf = SpiderFoot(self.default_options)
+
+        parse_links = sf.parseLinks('url', 'data', None)
+        self.assertEqual(dict, type(parse_links))
+
+    def test_url_encode_unicode_should_return_a_string(self):
         """
         Test urlEncodeUnicode(self, url)
         """
-        self.assertEqual('TBD', 'TBD')
+        sf = SpiderFoot(self.default_options)
+
+        url_encode_unicode = sf.urlEncodeUnicode('url')
+        self.assertEqual(str, type(url_encode_unicode))
 
     def test_fetch_url(self):
         """


### PR DESCRIPTION
Update Unit tests.

Current state of the tests:

```
____________________________________________________________________________ TestSpiderFoot.test_build_graph_data ____________________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_build_graph_data>

    def test_build_graph_data(self):
        """
        Test buildGraphData(self, data, flt=list())
        """
        sf = SpiderFoot(dict())
    
>       sf.buildGraphData(None)

test/unit/test_spiderfoot.py:102: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFoot object at 0x7f8e909c9c90>, data = None, flt = []

    def buildGraphData(self, data, flt=list()):
        mapping = set()
        entities = dict()
        parents = dict()
    
        def get_next_parent_entities(item, pids):
            ret = list()
    
            for [parent, id] in parents[item]:
                if id in pids:
                    continue
                if parent in entities:
                    ret.append(parent)
                else:
                    pids.append(id)
                    for p in get_next_parent_entities(parent, pids):
                        ret.append(p)
            return ret
    
>       for row in data:
E       TypeError: 'NoneType' object is not iterable

sflib.py:163: TypeError
____________________________________________________________________________ TestSpiderFoot.test_build_graph_gexf ____________________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_build_graph_gexf>

    def test_build_graph_gexf(self):
        """
        Test buildGraphGexf(self, root, title, data, flt=[])
        """
        sf = SpiderFoot(dict())
    
>       sf.buildGraphGexf(None, None, None)

test/unit/test_spiderfoot.py:111: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sflib.py:198: in buildGraphGexf
    mapping = self.buildGraphData(data, flt)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFoot object at 0x7f8e90973110>, data = None, flt = []

    def buildGraphData(self, data, flt=list()):
        mapping = set()
        entities = dict()
        parents = dict()
    
        def get_next_parent_entities(item, pids):
            ret = list()
    
            for [parent, id] in parents[item]:
                if id in pids:
                    continue
                if parent in entities:
                    ret.append(parent)
                else:
                    pids.append(id)
                    for p in get_next_parent_entities(parent, pids):
                        ret.append(p)
            return ret
    
>       for row in data:
E       TypeError: 'NoneType' object is not iterable

sflib.py:163: TypeError
____________________________________________________________________________ TestSpiderFoot.test_build_graph_json ____________________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_build_graph_json>

    def test_build_graph_json(self):
        """
        Test buildGraphJson(self, root, data, flt=list())
        """
        sf = SpiderFoot(dict())
    
>       sf.buildGraphJson(None, None)

test/unit/test_spiderfoot.py:120: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sflib.py:234: in buildGraphJson
    mapping = self.buildGraphData(data, flt)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFoot object at 0x7f8e909d5210>, data = None, flt = []

    def buildGraphData(self, data, flt=list()):
        mapping = set()
        entities = dict()
        parents = dict()
    
        def get_next_parent_entities(item, pids):
            ret = list()
    
            for [parent, id] in parents[item]:
                if id in pids:
                    continue
                if parent in entities:
                    ret.append(parent)
                else:
                    pids.append(id)
                    for p in get_next_parent_entities(parent, pids):
                        ret.append(p)
            return ret
    
>       for row in data:
E       TypeError: 'NoneType' object is not iterable

sflib.py:163: TypeError
_______________________________________________________________ TestSpiderFoot.test_cache_get_invalid_label_should_return_none _______________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_cache_get_invalid_label_should_return_none>

    def test_cache_get_invalid_label_should_return_none(self):
        """
        Test cacheGet(self, label, timeoutHrs)
        """
        sf = SpiderFoot(dict())
    
>       cache_get = sf.cacheGet(None, sf.opts.get('cacheperiod', 0))

test/unit/test_spiderfoot.py:251: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFoot object at 0x7f8e9a9ea890>, label = None, timeoutHrs = 0

    def cacheGet(self, label, timeoutHrs):
>       pathLabel = hashlib.sha224(label.encode('utf-8')).hexdigest()
E       AttributeError: 'NoneType' object has no attribute 'encode'

sflib.py:442: AttributeError
____________________________________________________________________ TestSpiderFoot.test_cache_get_should_return_a_string ____________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_cache_get_should_return_a_string>

    def test_cache_get_should_return_a_string(self):
        """
        Test cacheGet(self, label, timeoutHrs)
        """
        sf = SpiderFoot(dict())
    
        cache_get = sf.cacheGet('', sf.opts.get('cacheperiod', 0))
>       self.assertEqual(str, type(cache_get))
E       AssertionError: <class 'str'> != <class 'NoneType'>

test/unit/test_spiderfoot.py:243: AssertionError
_________________________________________________________________________________ TestSpiderFoot.test_error __________________________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_error>

    def test_error(self):
        """
        Test error(self, error, exception=True)
        """
        sf = SpiderFoot(self.default_options)
    
>       sf.error(None)

test/unit/test_spiderfoot.py:162: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFoot object at 0x7f8e909c94d0>, message = None, exception = True

    def error(self, message, exception=True):
        if not self.opts['__logging']:
            return None
    
        if self.dbh is None:
            print('[Error] %s' % message)
        else:
            self._dblog("ERROR", message)
        if self.opts.get('__logstdout'):
            print("[Error] %s" % message)
        if exception:
>           raise BaseException("Internal Error Encountered: " + message)
E           TypeError: can only concatenate str (not "NoneType") to str

sflib.py:318: TypeError
------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------
[Error] None
__________________________________________________________________ TestSpiderFoot.test_host_domain_should_return_a_boolean ___________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_host_domain_should_return_a_boolean>

    def test_host_domain_should_return_a_boolean(self):
        """
        Test hostDomain(self, hostname, tldList)
        """
        sf = SpiderFoot(dict())
    
>       host_doman = sf.hostDomain('local', None)

test/unit/test_spiderfoot.py:359: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sflib.py:766: in hostDomain
    ps = PublicSuffixList(tldList)
sflib.py:2070: in __init__
    root = self._build_structure(input_data)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.PublicSuffixList object at 0x7f8e9089c050>, fp = None

    def _build_structure(self, fp):
        root = [0]
    
>       for line in fp:
E       TypeError: 'NoneType' object is not iterable

sflib.py:2111: TypeError
____________________________________________________________________________ TestSpiderFoot.test_init_no_options _____________________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_init_no_options>

    def test_init_no_options(self):
        """
        Test __init__(self, options, handle=None):
        """
>       sf = SpiderFoot(None)

test/unit/test_spiderfoot.py:41: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFoot object at 0x7f8e9086d150>, options = None, handle = None

    def __init__(self, options, handle=None):
        self.handle = handle
        self.opts = deepcopy(options)
        # This is ugly but we don't want any fetches to fail - we expect
        # to encounter unverified SSL certs!
        if sys.version_info >= (2, 7, 9):
            ssl._create_default_https_context = ssl._create_unverified_context
    
>       if self.opts.get('_dnsserver', "") != "":
E       AttributeError: 'NoneType' object has no attribute 'get'

sflib.py:65: AttributeError
___________________________________________________________________ TestSpiderFoot.test_is_domain_should_return_a_boolean ____________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_is_domain_should_return_a_boolean>

    def test_is_domain_should_return_a_boolean(self):
        """
        Test isDomain(self, hostname, tldList)
        """
        sf = SpiderFoot(dict())
    
>       is_domain = sf.isDomain('local', None)

test/unit/test_spiderfoot.py:368: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sflib.py:788: in isDomain
    ps = PublicSuffixList(tldList)
sflib.py:2070: in __init__
    root = self._build_structure(input_data)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.PublicSuffixList object at 0x7f8e9086dbd0>, fp = None

    def _build_structure(self, fp):
        root = [0]
    
>       for line in fp:
E       TypeError: 'NoneType' object is not iterable

sflib.py:2111: TypeError
_____________________________________________________________ TestSpiderFoot.test_parse_links_invalid_data_should_return_a_dict ______________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_parse_links_invalid_data_should_return_a_dict>

    def test_parse_links_invalid_data_should_return_a_dict(self):
        """
        Test parseLinks(self, url, data, domains)
        """
        sf = SpiderFoot(self.default_options)
    
        parse_links = sf.parseLinks('url', None, 'domains')
>       self.assertEqual(dict, type(parse_links))
E       AssertionError: <class 'dict'> != <class 'NoneType'>

test/unit/test_spiderfoot.py:525: AssertionError
________________________________________________________________ TestSpiderFootPlugin.test_default_opts_should_return_a_dict _________________________________________________________________

self = <test.unit.test_spiderfootplugin.TestSpiderFootPlugin testMethod=test_default_opts_should_return_a_dict>

    def test_default_opts_should_return_a_dict(self):
        """
        Test defaultOpts(self)
        Note: this function is not currently used
        """
        sfp = SpiderFootPlugin()
    
>       default_opts = sfp.defaultOpts()

test/unit/test_spiderfootplugin.py:150: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFootPlugin object at 0x7f8e90a04810>

    def defaultOpts(self):
>       return self.opts
E       AttributeError: 'SpiderFootPlugin' object has no attribute 'opts'

sflib.py:1803: AttributeError
____________________________________________________________________________ TestSpiderFootPlugin.test_get_target ____________________________________________________________________________

self = <test.unit.test_spiderfootplugin.TestSpiderFootPlugin testMethod=test_get_target>

    def test_get_target(self):
        """
        Test getTarget(self)
        """
        sfp = SpiderFootPlugin()
    
>       sfp.getTarget()

test/unit/test_spiderfootplugin.py:96: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFootPlugin object at 0x7f8e90775c10>

    def getTarget(self):
        if self._currentTarget is None:
            print("Internal Error: Module called getTarget() but no target set.")
>           sys.exit(-1)
E           SystemExit: -1

sflib.py:1698: SystemExit
------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------
Internal Error: Module called getTarget() but no target set.
_____________________________________________________________________________ TestSpiderFootTarget.test_matches ______________________________________________________________________________

self = <test.unit.test_spiderfoottarget.TestSpiderFootTarget testMethod=test_matches>

    def test_matches(self):
        """
        Test matches(self, value, includeParents=False, includeChildren=True)
        """
        target_value = 'example target value'
        target_type = 'IP_ADDRESS'
        target = SpiderFootTarget(target_value, target_type)
    
>       target.matches(None)

test/unit/test_spiderfoottarget.py:104: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFootTarget object at 0x7f8e90849510>, value = None, includeParents = False, includeChildren = True

    def matches(self, value, includeParents=False, includeChildren=True):
>       value = value.lower()
E       AttributeError: 'NoneType' object has no attribute 'lower'

sflib.py:1921: AttributeError
____________________________________________________________________________ TestSpiderFootTarget.test_set_alias _____________________________________________________________________________

self = <test.unit.test_spiderfoottarget.TestSpiderFootTarget testMethod=test_set_alias>

    def test_set_alias(self):
        """
        Test setAlias(self, value, typeName)
        """
        target_value = 'example target value'
        target_type = 'IP_ADDRESS'
        target = SpiderFootTarget(target_value, target_type)
    
>       set_alias = target.setAlias(None, None)

test/unit/test_spiderfoottarget.py:49: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFootTarget object at 0x7f8e90855f50>, value = None, typeName = None

    def setAlias(self, value, typeName):
        if {'type': typeName, 'value': value} in self.targetAliases:
            return None
    
        self.targetAliases.append(
>           {'type': typeName, 'value': value.lower()}
        )
E       AttributeError: 'NoneType' object has no attribute 'lower'

sflib.py:1869: AttributeError
====================================================================================== warnings summary ======================================================================================
/usr/lib/python3/dist-packages/html5lib/_trie/_base.py:3
  /usr/lib/python3/dist-packages/html5lib/_trie/_base.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping

test/unit/test_spiderfoot.py::TestSpiderFoot::test_parse_links_invalid_domains_should_return_a_dict
test/unit/test_spiderfoot.py::TestSpiderFoot::test_parse_links_invalid_url_should_return_a_dict
test/unit/test_spiderfoot.py::TestSpiderFoot::test_parse_links_should_return_a_dict
  /usr/local/lib/python3.7/dist-packages/bs4/__init__.py:273: UserWarning: "b'data'" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.
    ' Beautiful Soup.' % markup)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================================== 15 failed, 100 passed, 4 warnings in 10.38s =========================================================================
```