### PR TITLE
Add check for response content

### DIFF
--- a/modules/sfp_crt.py
+++ b/modules/sfp_crt.py
@@ -147,6 +147,10 @@ class sfp_crt(SpiderFootPlugin):
                                    timeout=30,
                                    useragent=self.opts['_useragent'])
 
+            if res['content'] is None:
+                self.sf.info("Error retrieving certificate with ID " + str(cert_id))
+                continue
+
             try:
                 cert = self.sf.parseCert(str(res['content']))
             except BaseException as e:


### PR DESCRIPTION
Add check for response content.

In the event of a connection error, without this check, the module would fail with a certificate parsing error. The cause of the error was not obvious, requiring reviewing the logs to determine that the response size was zero bytes.
