### PR TITLE
sfwebui: Use scan name for JSON export filename

### DIFF
--- a/sfwebui.py
+++ b/sfwebui.py
@@ -205,6 +205,7 @@ class SpiderFootWebUi:
     def scanexportjsonmulti(self, ids):
         dbh = SpiderFootDb(self.config)
         scaninfo = list()
+        scan_name = ""
 
         for id in ids.split(','):
             scan = dbh.scanInstanceGet(id)
@@ -236,7 +237,12 @@ class SpiderFootWebUi:
                     "scan_target": scan[1]
                 })
 
-        cherrypy.response.headers['Content-Disposition'] = "attachment; filename=SpiderFoot.json"
+        if len(ids.split(',')) > 1 or scan_name == "":
+            fname = "SpiderFoot.json"
+        else:
+            fname = scan_name + "-SpiderFoot.json"
+
+        cherrypy.response.headers['Content-Disposition'] = "attachment; filename=" + fname
         cherrypy.response.headers['Content-Type'] = "application/json; charset=utf-8"
         cherrypy.response.headers['Pragma'] = "no-cache"
         return json.dumps(scaninfo).encode("utf-8")


### PR DESCRIPTION
Use scan name for JSON export filename in the form of `<scan name>-SpiderFoot.json`.

It's probably vulnerable to HTTP header injection - depending on how well the user input is validated (the `cleanUserInput` function is insufficient).
