### PR TITLE
Fixed the only line where whois error occurs (#502)

### DIFF
--- a/modules/sfp_whois.py
+++ b/modules/sfp_whois.py
@@ -65,7 +65,7 @@ class sfp_whois(SpiderFootPlugin):
         try:
             data = None
             if eventName != "NETBLOCK_OWNER":
-                whoisdata = whois.whois(eventData)
+                whoisdata = whois.query(eventData)
                 if whoisdata:
                     data = whoisdata.text
             else:


### PR DESCRIPTION
This change only updates the whois module to use the new functions provided by the updated whois library. I tested the webserver with this change, and I never saw any errors regarding the whois module.