### PR TITLE
Add extractUrls function to extract all URLs from a string

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -15,6 +15,7 @@ from stem import Signal
 from stem.control import Controller
 import inspect
 import hashlib
+import html
 import urllib.request, urllib.parse, urllib.error
 import json
 import re
@@ -1336,6 +1337,11 @@ class SpiderFoot:
                 ret['certerror'] = True
 
         return ret
+
+    # Extract all URLs from a string
+    # https://tools.ietf.org/html/rfc3986#section-3.3
+    def extractUrls(self, content):
+        return re.findall("(https?://[a-zA-Z0-9-\.:]+/[\-\._~!\$&'\(\)\*\+\,\;=:@/a-zA-Z0-9]*)", html.unescape(content))
 
     # Find all URLs within the supplied content. This does not fetch any URLs!
     # A dictionary will be returned, where each link will have the keys


### PR DESCRIPTION
Far from perfect.

```python
#!/usr/bin/env python3
import re
import html

# https://tools.ietf.org/html/rfc3986#section-3.3
content = "asdfhttp://zzz1234.asdf.zz.example.com:8080/1234/some/path?a=asdf>"
content += "<http://zzz5678.zxcv.zz.example.com:8080/5678/some/path/'%'?a=zxcv'%'''"
content += "<http://a@zzz9012.qewrty.zz.example.com:8080/9012/some/path?a=qwerty<"
print("Searching in: %s" % content)
print('...')

urls = re.findall("(https?://[a-zA-Z0-9-\.:]+/[\-\._~!\$&'\(\)\*\+\,\;=:@/%a-zA-Z0-9]*)", html.unescape(content))
for u in urls:
    print(u)
```

```
$ ./urltest.py 
Searching in: asdfhttp://zzz1234.asdf.zz.example.com:8080/1234/some/path?a=asdf><http://zzz5678.zxcv.zz.example.com:8080/5678/some/path/'%'?a=zxcv'%'''<http://a@zzz9012.qewrty.zz.example.com:8080/9012/some/path?a=qwerty<
...
http://zzz1234.asdf.zz.example.com:8080/1234/some/path
http://zzz5678.zxcv.zz.example.com:8080/5678/some/path/'%'
```

