### PR TITLE
Silence bandit false positive warnings

### DIFF
--- a/modules/sfp_dnsbrute.py
+++ b/modules/sfp_dnsbrute.py
@@ -103,7 +103,7 @@ class sfp_dnsbrute(SpiderFootPlugin):
         # Spawn threads for scanning
         self.sf.info("Spawning threads to check hosts: " + str(hostList))
         for name in hostList:
-            tn = 'thread_sfp_dnsbrute_' + str(random.randint(0, 999999999))
+            tn = 'thread_sfp_dnsbrute_' + str(random.SystemRandom().randint(1, 999999999))
             t.append(threading.Thread(name=tn, target=self.tryHost, args=(name,)))
             t[i].start()
             i += 1

--- a/modules/sfp_gravatar.py
+++ b/modules/sfp_gravatar.py
@@ -53,7 +53,7 @@ class sfp_gravatar(SpiderFootPlugin):
     # https://secure.gravatar.com/site/implement/
     # https://secure.gravatar.com/site/implement/profiles/
     def query(self, qry):
-        email_hash = hashlib.md5(qry.encode('utf-8', errors='replace').lower()).hexdigest()
+        email_hash = hashlib.md5(qry.encode('utf-8', errors='replace').lower()).hexdigest() # nosec
         output = 'json'
 
         res = self.sf.fetchUrl("https://secure.gravatar.com/" + email_hash + '.' + output,

--- a/sflib.py
+++ b/sflib.py
@@ -2314,7 +2314,9 @@ class PublicSuffixList(object):
         if len(parent) == 1:
             parent.append({})
 
-        assert len(parent) == 2
+        if len(parent) != 2
+            return None
+
         negate, children = parent
 
         child = parts.pop()

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -43,7 +43,7 @@ class SpiderFootWebUi:
         sf = SpiderFoot(self.defaultConfig)
         self.config = sf.configUnserialize(dbh.configGet(), self.defaultConfig)
 
-        if self.config['__webaddr'] == "0.0.0.0":
+        if self.config['__webaddr'] == "0.0.0.0": # nosec
             addr = "<IP of this host>"
         else:
             addr = self.config['__webaddr']


### PR DESCRIPTION
* `assert` should not be used. Replaced `assert len(parent) == 2` with `if len(parent) != 2: return None`.

* `random.randint` was used for thread names which does require secure random. Replaced with `random.SystemRandom().randint`

* Use of MD5 was required for querying a remote service by md5 hash. Added `# nosec`.

* `0.0.0.0` was a false positive. This exists in a conditional statement which checks (not sets) the network interface. `0.0.0.0` is not the default network interface. Added `# nosec`.
