### PR TITLE
Add missing commas in producedEvents arrays

### DIFF
--- a/modules/sfp_multiproxy.py
+++ b/modules/sfp_multiproxy.py
@@ -68,7 +68,7 @@ class sfp_multiproxy(SpiderFootPlugin):
     # This is to support the end user in selecting modules based on events
     # produced.
     def producedEvents(self):
-        return ["MALICIOUS_IPADDR" "MALICIOUS_AFFILIATE_IPADDR"]
+        return ["MALICIOUS_IPADDR", "MALICIOUS_AFFILIATE_IPADDR"]
 
     # Check the regexps to see whether the content indicates maliciousness
     def contentMalicious(self, content, goodregex, badregex):

--- a/modules/sfp_watchguard.py
+++ b/modules/sfp_watchguard.py
@@ -65,7 +65,7 @@ class sfp_watchguard(SpiderFootPlugin):
     # This is to support the end user in selecting modules based on events
     # produced.
     def producedEvents(self):
-        return ["MALICIOUS_IPADDR" "MALICIOUS_AFFILIATE_IPADDR" ]
+        return ["MALICIOUS_IPADDR", "MALICIOUS_AFFILIATE_IPADDR" ]
 
     # Check the regexps to see whether the content indicates maliciousness
     def contentMalicious(self, content, goodregex, badregex):


### PR DESCRIPTION
The missing commas are causing the produced event names to be concatenated. 