### PR TITLE
Fixed webui query route. Used redirects instead of rerender for some routes.

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -383,10 +383,16 @@ if __name__ == '__main__':
 
     # Enable access to static files via the web directory
     currentDir = os.path.abspath(sf.myPath())
-    conf = {'/static': {
-        'tools.staticdir.on': True,
-        'tools.staticdir.dir': os.path.join(currentDir, 'static')
-    }}
+    conf = {
+        '/query': {
+            'tools.encode.text_only': False,
+            'tools.encode.add_charset': True,
+        },
+        '/static': {
+            'tools.staticdir.on': True,
+            'tools.staticdir.dir': os.path.join(currentDir, 'static')
+        }
+    }
 
     passwd_file = sf.myPath() + '/passwd'
     if os.path.isfile(passwd_file):

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -626,10 +626,8 @@ class SpiderFootWebUi:
         except Exception as e:
             return self.error("Processing one or more of your inputs failed: " + str(e))
 
-        templ = Template(filename='dyn/opts.tmpl', lookup=self.lookup)
-        self.token = random.SystemRandom().randint(0, 99999999)
-        return templ.render(opts=self.config, pageid='SETTINGS', updated=True,
-                            docroot=self.docroot, token=self.token)
+
+        raise cherrypy.HTTPRedirect("/opts")
 
     savesettings.exposed = True
 
@@ -749,6 +747,8 @@ class SpiderFootWebUi:
         try:
             ret = dbh.dbh.execute(query)
             data = ret.fetchall()
+            columnNames = [c[0] for c in dbh.dbh.description]
+            data = [dict(zip(columnNames, row)) for row in data]
         except BaseException as e:
             return json.dumps(["ERROR", str(e)])
 
@@ -846,9 +846,7 @@ class SpiderFootWebUi:
             time.sleep(1)
 
         if not cli:
-            templ = Template(filename='dyn/scaninfo.tmpl', lookup=self.lookup)
-            return templ.render(id=scanId, name=scanname, docroot=self.docroot,
-                                status=dbh.scanInstanceGet(scanId), pageid="SCANLIST")
+            raise cherrypy.HTTPRedirect(f"/scaninfo?id={scanId}")
         else:
             return json.dumps(["SUCCESS", scanId])
 
@@ -884,9 +882,7 @@ class SpiderFootWebUi:
                 #set the scanstatus in the db to "ABORT-REQUESTED"
                 dbh.scanInstanceSet(id, status="ABORT-REQUESTED")
 
-        templ = Template(filename='dyn/scanlist.tmpl', lookup=self.lookup)
-        return templ.render(pageid='SCANLIST', stoppedscan=True,
-                            errors=error, docroot=self.docroot)
+        raise cherrypy.HTTPRedirect("/")
 
     stopscanmulti.exposed = True
 
@@ -920,8 +916,7 @@ class SpiderFootWebUi:
 
         dbh.scanInstanceSet(id, status="ABORT-REQUESTED")
         if not cli:
-            templ = Template(filename='dyn/scanlist.tmpl', lookup=self.lookup)
-            return templ.render(pageid='SCANLIST', stoppedscan=True, docroot=self.docroot, errors=list())
+            raise cherrypy.HTTPRedirect("/")
         else:
             return json.dumps(["SUCCESS", ""])
 


### PR DESCRIPTION
The query route was having problems with utf-8 encoding of the results and was not able to JSON-encode a list with tuples. I changed the result to a list of dictionaries and enabled utf-8 encoding in CherryPy.

For the webui routes that invoke an action and then show a page for monitoring (rescan, etc.), I changed the behavior to invoke the action and then redirect to the monitoring page rather than rendering the target page in the handler. This helps to prevent accidental resubmission if the user refreshes the page and makes the monitoring page URL bookmark-friendly. 

I also corrected the pageid value for some of the template rendering functions.