### PR TITLE
sflib: validate domainKeywords function input

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -745,6 +745,10 @@ class SpiderFoot:
             str: The keyword
         """
 
+        if not domain:
+            self.error("Invalid domain: %s" % domain, False)
+            return None
+
         # Strip off the TLD
         tld = '.'.join(self.hostDomain(domain.lower(), tldList).split('.')[1:])
         ret = domain.lower().replace('.' + tld, '')
@@ -755,27 +759,27 @@ class SpiderFoot:
         else:
             return ret
 
-    # TODO: remove this function
     def domainKeywords(self, domainList, tldList):
         """Extract the keywords (the domains without the TLD or any subdomains) from a list of domains.
-
-        Wraps the domainKeyword function for people who are too lazy to write a loop.
-        Does not validate input. Does not check for duplicates.
 
         Args:
             domainList (list): The list of domains to check.
             tldList (str): The list of TLDs based on the Mozilla public list.
 
         Returns:
-            list: List of keywords
+            set: List of keywords
         """
 
-        arr = list()
-        for domain in domainList:
-            arr.append(self.domainKeyword(domain, tldList))
+        if not domainList:
+            self.error("Invalid domain list: %s" % domainList, False)
+            return set()
 
-        self.debug("Keywords: " + str(arr))
-        return arr
+        keywords = list()
+        for domain in domainList:
+            keywords.append(self.domainKeyword(domain, tldList))
+
+        self.debug("Keywords: %s" % keywords)
+        return set([k for k in keywords if k])
 
     def hostDomain(self, hostname, tldList):
         """Obtain the domain name for a supplied hostname.

--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -347,7 +347,20 @@ class TestSpiderFoot(unittest.TestCase):
         self.assertEqual(str, type(keyword))
         self.assertEqual('wwwspiderfootnet', keyword)
 
-    def test_domain_keywords_should_return_a_list(self):
+    def test_domain_keyword_invalid_domain_should_return_none(self):
+        """
+        Test domainKeyword(self, domain, tldList)
+        """
+        sf = SpiderFoot(self.default_options)
+
+        keyword = sf.domainKeyword("", sf.opts.get('_internettlds'))
+        self.assertEqual(None, keyword)
+        keyword = sf.domainKeyword([], sf.opts.get('_internettlds'))
+        self.assertEqual(None, keyword)
+        keyword = sf.domainKeyword(None, sf.opts.get('_internettlds'))
+        self.assertEqual(None, keyword)
+
+    def test_domain_keywords_should_return_a_set(self):
         """
         Test domainKeywords(self, domainList, tldList)
         """
@@ -355,7 +368,20 @@ class TestSpiderFoot(unittest.TestCase):
 
         domain_list = ['www.example.com', 'localhost.local']
         keywords = sf.domainKeywords(domain_list, sf.opts.get('_internettlds'))
-        self.assertEqual(list, type(keywords))
+        self.assertEqual(set, type(keywords))
+
+    def test_domain_keywords_invalid_domainlist_should_return_a_set(self):
+        """
+        Test domainKeyword(self, domain, tldList)
+        """
+        sf = SpiderFoot(self.default_options)
+
+        keywords = sf.domainKeywords("", sf.opts.get('_internettlds'))
+        self.assertEqual(set, type(keywords))
+        keywords = sf.domainKeywords([], sf.opts.get('_internettlds'))
+        self.assertEqual(set, type(keywords))
+        keywords = sf.domainKeywords(None, sf.opts.get('_internettlds'))
+        self.assertEqual(set, type(keywords))
 
     def test_host_domain_invalid_host_should_return_none(self):
         """


### PR DESCRIPTION
Validates input to `domainKeyword` and `domainKeywords` functions.

Changes `domainKeywords` out from `list()` to `set()`, thus removing duplicates. Also removes all `None` values from the returned `set()`.