### PR TITLE
Added support for configurable SpiderFoot data directory.

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -392,7 +392,7 @@ if __name__ == '__main__':
         'tools.staticdir.dir': os.path.join(currentDir, 'static')
     }}
 
-    passwd_file = sf.myPath() + '/passwd'
+    passwd_file = sf.dataPath() + '/passwd'
     if os.path.isfile(passwd_file):
         if not os.access(passwd_file, os.R_OK):
             print("Could not read passwd file. Permission denied.")
@@ -427,8 +427,8 @@ if __name__ == '__main__':
         else:
             print("Warning: passwd file contains no passwords. Authentication disabled.")
 
-    key_path = sf.myPath() + '/spiderfoot.key'
-    crt_path = sf.myPath() + '/spiderfoot.crt'
+    key_path = sf.dataPath() + '/spiderfoot.key'
+    crt_path = sf.dataPath() + '/spiderfoot.crt'
     if os.path.isfile(key_path) and os.path.isfile(crt_path):
         if not os.access(crt_path, os.R_OK):
             print("Could not read spiderfoot.crt file. Permission denied.")

--- a/sfdb.py
+++ b/sfdb.py
@@ -247,7 +247,7 @@ class SpiderFootDb:
         # connect() will create the database file if it doesn't exist, but
         # at least we can use this opportunity to ensure we have permissions to
         # read and write to such a file.
-        dbh = sqlite3.connect(self.sf.myPath() + "/" + opts['__database'], timeout=10)
+        dbh = sqlite3.connect(self.sf.dataPath() + "/" + opts['__database'], timeout=10)
         if dbh is None:
             self.sf.fatal("Could not connect to internal database, and couldn't create " + opts['__database'])
         dbh.text_factory = str

--- a/sflib.py
+++ b/sflib.py
@@ -396,7 +396,8 @@ class SpiderFoot:
             print("[d:%s] %s" % (modName, message))
         return
 
-    def myPath(self):
+    @staticmethod
+    def myPath():
         # This will get us the program's directory, even if we are frozen using py2exe.
 
         # Determine whether we've been compiled by py2exe
@@ -404,6 +405,12 @@ class SpiderFoot:
             return os.path.dirname(sys.executable)
 
         return os.path.dirname(__file__)
+
+    @classmethod
+    def dataPath(cls):
+        """Returns the location of spiderfoot data and configuration files."""
+        path = os.environ['SPIDERFOOT_DATA']
+        return path if path is not None else cls.myPath()
 
     def hashstring(self, string):
         s = string
@@ -2031,12 +2038,11 @@ class SpiderFootPlugin(object):
 
                 listener.handleEvent(sfEvent)
             except BaseException as e:
-                f = open("sferror.log", "a")
-                f.write("[" + time.ctime() + "]: Module (" + listener.__module__ + ") encountered an error: " + str(e) + "\n")
-
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                f.write(repr(traceback.format_exception(exc_type, exc_value, exc_traceback)))
-                f.close()
+                with open(os.path.join(SpiderFoot.dataPath(), "sferror.log"), "a") as f:
+                    f.write("[" + time.ctime() + "]: Module (" + listener.__module__ +
+                            ") encountered an error: " + str(e) + "\n")
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    f.write(repr(traceback.format_exception(exc_type, exc_value, exc_traceback)))
 
     # For modules to use to check for when they should give back control
     def checkForStop(self):


### PR DESCRIPTION
Added a dataPath method that queries a SPIDERFOOT_DATA environment variable for an optional override to where data files are stored. The default behavior is the same as before where all data and configs are stored in the sflib.myPath location. This change will allow Docker-based deployments to specify a Docker volume for data/config storage, allowing non-destructive container upgrades. #478