### PR TITLE
Remove duplicated test dependencies

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,5 +3,3 @@ pytest==5.3.0
 pytest-mock==1.12.0
 responses==0.10.6
 pytest-cov==2.8.1
-stem==1.8.0
-netaddr=0.7.19


### PR DESCRIPTION
Remove duplicated dependencies from `requirements_test.txt`.

The `netaddr` requirement was malformed.

```
$ pip3.7 install -r requirements_test.txt
...
ERROR: Invalid requirement: 'netaddr=0.7.19' (from line 7 of requirements_test.txt)
Hint: = is not a valid operator. Did you mean == ?
```

After fixing the formatting, it was revealed to be a duplicated dependency (as was `stem`), as per:

```
$ pip3.7 install -r requirements_test.txt
...
ERROR: Double requirement given: stem==1.8.0 (from -r requirements_test.txt (line 7)) (already in stem>=1.7.1 (from -r requirements.txt (line 16)), name='stem')
...
ERROR: Double requirement given: netaddr==0.7.19 (from -r requirements_test.txt (line 7)) (already in netaddr>=0.7.18 (from -r requirements.txt (line 8)), name='netaddr')
```


