### PR TITLE
sflib: Ensure resolveTargets always returns a list

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -1350,9 +1350,21 @@ class SpiderFoot:
         return False
 
     def resolveTargets(self, target, validateReverse):
-        """Resolve alternative names for a given target."""
+        """Resolve alternative names for a given target.
+
+        Args:
+            target (SpiderFootTarget): target object
+            validateReverse (bool): validate domain names resolve
+
+        Returns:
+            list: list of domain names and IP addresses
+        """
 
         ret = list()
+
+        if not target:
+            return ret
+
         t = target.getType()
         v = target.getValue()
 
@@ -1384,9 +1396,7 @@ class SpiderFoot:
                                     ret.append(host)
                     else:
                         ret.extend(names)
-        if len(ret) > 0:
-            return list(set(ret))
-        return None
+        return list(set(ret))
 
     def safeSocket(self, host, port, timeout):
         """Create a safe socket that's using SOCKS/TOR if it was enabled."""


### PR DESCRIPTION
Ensure `resolveTargets()` always returns a list. Rather than return `None` upon failure, an empty `list()` is returned instead.

The `resolveTargets` function is only used in one location - the sfp_dnsresolve module. An empty `list()` is effectively the same as `None` (ie, `False`), so this change should not affect the existing validation in use in this module:

```python
        ret = self.sf.resolveTargets(target, self.opts['validatereverse'])
        if not ret:
            return target
```