### PR TITLE
sflib: Ensure parseCert function returns None if provided certificate is invalid

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -1627,7 +1627,20 @@ class SpiderFoot:
 
     # Parse a PEM-format SSL certificate
     def parseCert(self, rawcert, fqdn=None, expiringdays=30):
-        """Parse a PEM-format SSL certificate."""
+        """Parse a PEM-format SSL certificate.
+
+        Args:
+            rawcert (str): TBD
+            fqdn (str): TBD
+            expiringdays (int): TBD
+
+        Returns:
+            dict: certificate details
+        """
+
+        if not rawcert:
+            self.error("Invalid certificate: %s" % rawcert, False)
+            return None
 
         ret = dict()
         if '\r' in rawcert:


### PR DESCRIPTION
Ideally this function should handle certificates more gracefully. Optionally, perhaps this function should return a `dict()` with `CertError = True` in the event of failure. This function is already kind of a mess and performs very little validation. For now, this change will act as early warning for invalid use of this function.
