### PR TITLE
sflib: Ensure resolveHost/resolveIP function input is not None

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -1295,6 +1295,10 @@ class SpiderFoot:
     def resolveHost(self, host):
         """Return a normalised resolution or None if not resolved."""
 
+        if not host:
+            self.error("Invalid host", False)
+            return None
+
         try:
             addrs = self.normalizeDNS(socket.gethostbyname_ex(host))
             if len(addrs) > 0:
@@ -1307,7 +1311,11 @@ class SpiderFoot:
     def resolveIP(self, ipaddr):
         """Return a normalised resolution of an IPv4 address or None if not resolved."""
 
-        self.debug("Performing reverse-resolve of " + ipaddr)
+        if not ipaddr:
+            self.error("Invalid IP address", False)
+            return None
+
+        self.debug("Performing reverse-resolve of %s" % ipaddr)
 
         try:
             addrs = self.normalizeDNS(socket.gethostbyaddr(ipaddr))
@@ -1320,6 +1328,10 @@ class SpiderFoot:
 
     def resolveHost6(self, hostname):
         """Return a normalised resolution of an IPv6 address or None if not resolved."""
+
+        if not hostname:
+            self.error("Invalid hostname", False)
+            return None
 
         try:
             addrs = list()


### PR DESCRIPTION
Fixes test:

```
======================================================================
ERROR: test_resolve_ip_invalid_ip_should_return_none (test_spiderfoot.TestSpiderFoot)
Test resolveIP(self, ipaddr)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/Desktop/spiderfoot/test/unit/test_spiderfoot.py", line 670, in test_resolve_ip_invalid_ip_should_return_none
    addrs = sf.resolveIP(None)
  File "/root/Desktop/spiderfoot/sflib.py", line 1335, in resolveIP
    self.debug("Performing reverse-resolve of " + ipaddr)
TypeError: can only concatenate str (not "NoneType") to str

```
