### PR TITLE
sflib: Ensure targetType target param is not empty

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -750,6 +750,8 @@ class SpiderFoot:
         Returns:
             str: scan target seed data type
         """
+        if not target:
+            return None
 
         targetType = None
 
@@ -758,8 +760,8 @@ class SpiderFoot:
             {"^\d+\.\d+\.\d+\.\d+/\d+$": "NETBLOCK_OWNER"},
             {"^.*@.*$": "EMAILADDR"},
             {"^\+\d+$": "PHONE_NUMBER"},
-            {"^\".*\s+.*\"$": "HUMAN_NAME"},
-            {"^\".*\"$": "USERNAME"},
+            {"^\".+\s+.+\"$": "HUMAN_NAME"},
+            {"^\".+\"$": "USERNAME"},
             {"^\d+$": "BGP_AS_OWNER"},
             {"^[0-9a-f:]+$": "IPV6_ADDRESS"},
             {"^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)+([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$": "INTERNET_NAME"}


### PR DESCRIPTION
Resolves `test_target_type_invalid_seed_should_return_none ` failing test.

Check for `None` prevents:

```
______________________________________________________________ TestSpiderFoot.test_target_type_invalid_seed_should_return_none _______________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_target_type_invalid_seed_should_return_none>

    def test_target_type_invalid_seed_should_return_none(self):
        """
        Test targetType(self, target)
        """
        sf = SpiderFoot(dict())
    
>       target_type = sf.targetType(None)

test/unit/test_spiderfoot.py:331: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sflib.py:773: in targetType
    if re.match(rx, target, re.IGNORECASE|re.UNICODE):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pattern = '^\\d+\\.\\d+\\.\\d+\\.\\d+$', string = None, flags = re.IGNORECASE|re.UNICODE

    def match(pattern, string, flags=0):
        """Try to apply the pattern at the start of the string, returning
        a Match object, or None if no match was found."""
>       return _compile(pattern, flags).match(string)
E       TypeError: expected string or bytes-like object

/usr/lib/python3.8/re.py:191: TypeError

```

Check for non-empty quoted string prevents:

```
______________________________________________________________ TestSpiderFoot.test_target_type_invalid_seed_should_return_none _______________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_target_type_invalid_seed_should_return_none>

    def test_target_type_invalid_seed_should_return_none(self):
        """
        Test targetType(self, target)
        """
        sf = SpiderFoot(dict())
    
        target_type = sf.targetType(None)
        self.assertEqual(None, target_type)
    
        target_type = sf.targetType("")
        self.assertEqual(None, target_type)
    
        target_type = sf.targetType('""')
>       self.assertEqual(None, target_type)
E       AssertionError: None != 'USERNAME'

test/unit/test_spiderfoot.py:338: AssertionError
```

