### PR TITLE
sflib: Ensure parseEmails returns a list

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -1511,6 +1511,9 @@ class SpiderFoot:
             list: list of email addresses
         """
 
+        if not isinstance(data, str):
+            return list()
+
         emails = set()
         matches = re.findall(r'([\%a-zA-Z\.0-9_\-\+]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)', data)
 


### PR DESCRIPTION
Resolves failing `test_parse_emails_invalid_data_should_return_list` test.

```
______________________________________________________________ TestSpiderFoot.test_parse_emails_invalid_data_should_return_list ______________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_parse_emails_invalid_data_should_return_list>

    def test_parse_emails_invalid_data_should_return_list(self):
        """
        Test parseEmails(self, data)
        """
        sf = SpiderFoot(self.default_options)
    
>       parse_emails = sf.parseEmails(None)

test/unit/test_spiderfoot.py:759: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sflib.py:1515: in parseEmails
    matches = re.findall(r'([\%a-zA-Z\.0-9_\-\+]+@[a-zA-Z\.0-9\-]+\.[a-zA-Z\.0-9\-]+)', data)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pattern = '([\\%a-zA-Z\\.0-9_\\-\\+]+@[a-zA-Z\\.0-9\\-]+\\.[a-zA-Z\\.0-9\\-]+)', string = None, flags = 0

    def findall(pattern, string, flags=0):
        """Return a list of all non-overlapping matches in the string.
    
        If one or more capturing groups are present in the pattern, return
        a list of groups; this will be a list of tuples if the pattern
        has more than one group.
    
        Empty matches are included in the result."""
>       return _compile(pattern, flags).findall(string)
E       TypeError: expected string or bytes-like object

/usr/lib/python3.8/re.py:241: TypeError
```
