### PR TITLE
sflib: Ensure normalizeDNS returns a list

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -1169,6 +1169,10 @@ class SpiderFoot:
         """
 
         ret = list()
+
+        if not res:
+            return ret
+
         for addr in res:
             if type(addr) == list:
                 for host in addr:


### PR DESCRIPTION
Resolve failing `test_normalize_dns_should_return_list` test.

```
____________________________________________________________________ TestSpiderFoot.test_normalize_dns_should_return_list ____________________________________________________________________

self = <test.unit.test_spiderfoot.TestSpiderFoot testMethod=test_normalize_dns_should_return_list>

    def test_normalize_dns_should_return_list(self):
        """
        Test normalizeDNS(self, res)
        """
        sf = SpiderFoot(self.default_options)
    
>       dns = sf.normalizeDNS(None)

test/unit/test_spiderfoot.py:566: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sflib.SpiderFoot object at 0x7f8f667676d0>, res = None

    def normalizeDNS(self, res):
        """Clean DNS results to be a simple list
    
        Args:
            res (list): List of DNS names
    
        Returns:
            list: list of domains
        """
    
        ret = list()
>       for addr in res:
E       TypeError: 'NoneType' object is not iterable

sflib.py:1172: TypeError
```
