### PR TITLE
sflib: Ensure _dblog without database handle raises exception

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -357,10 +357,11 @@ class SpiderFoot:
 
         return json.dumps(ret)
 
-    # Called usually some time after instantiation
-    # to set up a database handle and scan GUID, used
-    # for logging events to the database about a scan.
     def setDbh(self, handle):
+        """Called usually some time after instantiation
+        to set up a database handle and scan GUID, used
+        for logging events to the database about a scan.
+        """
         self.dbh = handle
 
     def setGUID(self, uid):
@@ -393,10 +394,15 @@ class SpiderFoot:
             component (str): TBD
 
         Returns:
-            bool: True
+            bool: scan event logged successfully
         """
 
         #print(str(self.GUID) + ":" + str(level) + ":" + str(message) + ":" + str(component))
+
+        if not self.dbh:
+            self.error("No database handle. Could not log event to database: %s" % message, True)
+            return False
+
         return self.dbh.scanLogEvent(self.GUID, level, message, component)
 
     def error(self, message, exception=True):

--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -152,19 +152,14 @@ class TestSpiderFoot(unittest.TestCase):
         scan_instance_id = sf.genScanInstanceGUID(None)
         self.assertIsInstance(scan_instance_id, str)
 
-    def test_dblog(self):
+    def test_dblog_invalid_dbh_should_raise(self):
         """
         Test _dblog(self, level, message, component=None)
         """
-        sf = SpiderFoot(dict())
+        sf = SpiderFoot(self.default_options)
 
-        self.assertEqual('TBD', 'TBD')
-
-        dblog = sf._dblog("", "", "")
-        self.assertTrue(dblog)
-
-        dblog = sf._dblog(None, None, None)
-        self.assertTrue(dblog)
+        with self.assertRaises(BaseException) as cm:
+            dblog = sf._dblog(None, None, None)
 
     def test_error(self):
         """


### PR DESCRIPTION
Ideally this would check the database handle is a valid `SpiderFootDb` object (rather than simply checking `if not`) and `setDbh` would also ensure the provided database handle is a valid `SpiderFootDb` object when setting `self.dbh` in the first place; however, that would require importing `SpiderFootDb` into `sflib` which is not possible currently due to circular dependencies.
