### PR TITLE
Add pycodestyle to test requirements

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ pytest==5.3.0
 pytest-mock==1.12.0
 responses==0.10.6
 pytest-cov==2.8.1
+pycodestyle==2.6.0


### PR DESCRIPTION
Required by `./test/test_pep8.py` for code style tests