### PR TITLE
Prevent irrelevant Beautiful Soup warnings

### DIFF
--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -829,7 +829,7 @@ class TestSpiderFoot(unittest.TestCase):
         """
         sf = SpiderFoot(self.default_options)
 
-        parse_links = sf.parseLinks('url', 'data', 'domains')
+        parse_links = sf.parseLinks('url', 'example html content', 'domains')
         self.assertIsInstance(parse_links, dict)
 
     def test_parse_links_invalid_url_should_return_a_dict(self):
@@ -838,7 +838,7 @@ class TestSpiderFoot(unittest.TestCase):
         """
         sf = SpiderFoot(self.default_options)
 
-        parse_links = sf.parseLinks(None, 'data', 'domains')
+        parse_links = sf.parseLinks(None, 'example html content', 'domains')
         self.assertIsInstance(parse_links, dict)
 
     def test_parse_links_invalid_data_should_return_a_dict(self):
@@ -856,7 +856,7 @@ class TestSpiderFoot(unittest.TestCase):
         """
         sf = SpiderFoot(self.default_options)
 
-        parse_links = sf.parseLinks('url', 'data', None)
+        parse_links = sf.parseLinks('url', 'example html content', None)
         self.assertEqual(dict, type(parse_links))
 
     def test_url_encode_unicode_should_return_a_string(self):


### PR DESCRIPTION
Prevent generating the following warnings in unit tests:

```
test/unit/test_spiderfoot.py::TestSpiderFoot::test_parse_links_invalid_domains_should_return_a_dict
test/unit/test_spiderfoot.py::TestSpiderFoot::test_parse_links_invalid_url_should_return_a_dict
test/unit/test_spiderfoot.py::TestSpiderFoot::test_parse_links_should_return_a_dict
  /usr/lib/python3/dist-packages/bs4/__init__.py:329: MarkupResemblesLocatorWarning: "data" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.
    warnings.warn(
```
