### PR TITLE
tests: re-add test/unit/test_spiderfootscanstatus.py

### DIFF
--- a/test/unit/test_spiderfootscanstatus.py
+++ b/test/unit/test_spiderfootscanstatus.py
@@ -1,0 +1,55 @@
+# test_spiderfootscanstatus.py
+from sflib import SpiderFootScanStatus
+import unittest
+
+class TestSpiderFootScanStatus(unittest.TestCase):
+    """
+    Test SpiderFootScanStatus
+    """
+
+    def test_set_status_should_return_none(self):
+        """
+        Test setStatus(self, scanId, status)
+        """
+        globalScanStatus = SpiderFootScanStatus()
+
+        scan_id = 'example scan id'
+        status = 'example status'
+
+        scan_status = globalScanStatus.setStatus(scan_id, status)
+        self.assertEqual(None, scan_status)
+
+    def test_get_status_should_return_a_string(self):
+        """
+        Test getStatus(self, scanId)
+        """
+        globalScanStatus = SpiderFootScanStatus()
+
+        scan_id = 'example scan id'
+        status = 'example status'
+        globalScanStatus.setStatus(scan_id, status)
+
+        scan_status = globalScanStatus.getStatus(scan_id)
+        self.assertEqual(status, scan_status)
+
+    def test_get_status_invalid_status_should_return_none(self):
+        """
+        Test getStatus(self, scanId)
+        """
+        globalScanStatus = SpiderFootScanStatus()
+
+        scan_status = globalScanStatus.getStatus(None)
+        self.assertEqual(None, scan_status)
+
+    def test_get_status_all_should_return_a_dict(self):
+        """
+        Test getStatusAll(self)
+        """
+        globalScanStatus = SpiderFootScanStatus()
+
+        scan_status = globalScanStatus.getStatusAll()
+        self.assertEqual(dict, type(scan_status))
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
So long as the `SpiderFootScanStatus` class exists in `sflib` there should be tests for it. Please stop deleting the tests. #566 

Rather than delete these tests, they should be improved, perhaps by using the global `globalScanStatus` variable.
