### PR TITLE
sfscan: move startScan() functionality out of init()

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -369,11 +369,8 @@ class SpiderFoot:
         """Set the GUID this instance of SpiderFoot is being used in."""
         self.GUID = uid
 
-    def genScanInstanceGUID(self, scanName):
+    def genScanInstanceGUID(self):
         """Generate an globally unique ID for this scan.
-
-        Args:
-            scanName (str): scan name
 
         Returns:
             str: scan instance unique GUID
@@ -636,10 +633,24 @@ class SpiderFoot:
     # Configuration process
     #
 
-    # Convert a Python dictionary to something storable
-    # in the database.
     def configSerialize(self, opts, filterSystem=True):
+        """Convert a Python dictionary to something storable in the database.
+
+        Args:
+            opts (dict): TBD
+            filterSystem (bool): TBD
+
+        Returns:
+            dict: config options
+        """
+
+        if not isinstance(opts, dict):
+            raise TypeError("opts is %s; expected dict()" % type(opts))
+
         storeopts = dict()
+
+        if not opts:
+            return storeopts
 
         for opt in list(opts.keys()):
             # Filter out system temporary variables like GUID and others
@@ -657,7 +668,7 @@ class SpiderFoot:
             if type(opts[opt]) is list:
                 storeopts[opt] = ','.join(opts[opt])
 
-        if '__modules__' not in opts:
+        if opts['__modules__'] is None:
             return storeopts
 
         for mod in opts['__modules__']:
@@ -680,11 +691,26 @@ class SpiderFoot:
 
         return storeopts
 
-    # Take strings, etc. from the database or UI and convert them
-    # to a dictionary for Python to process.
-    # referencePoint is needed to know the actual types the options
-    # are supposed to be.
     def configUnserialize(self, opts, referencePoint, filterSystem=True):
+        """Take strings, etc. from the database or UI and convert them
+        to a dictionary for Python to process.
+        referencePoint is needed to know the actual types the options
+        are supposed to be.
+
+        Args:
+            opts (dict): TBD
+            referencePoint (dict): TBD
+            filterSystem (bool): TBD
+
+        Returns:
+            dict: TBD
+        """
+
+        if not isinstance(opts, dict):
+            raise TypeError("opts is %s; expected dict()" % type(opts))
+        if not isinstance(referencePoint, dict):
+            raise TypeError("referencePoint is %s; expected dict()" % type(referencePoint))
+
         returnOpts = referencePoint
 
         # Global options
@@ -2535,14 +2561,16 @@ class SpiderFootTarget(object):
     targetAliases = list()
 
     def __init__(self, targetValue, typeName):
+        if not isinstance(targetValue, str):
+            raise TypeError("Invalid target value %s; expected %s" % type(targetValue))
         if typeName not in self._validTypes:
             raise ValueError("Invalid target type %s; expected %s" % (typeName, self._validTypes))
 
         self.targetType = typeName
-        if type(targetValue) != str:
-            self.targetValue = str(targetValue).lower()
-        else:
+        if isinstance(targetValue, str):
             self.targetValue = targetValue
+        else:
+            self.targetValue = str(targetValue).lower()
         self.targetAliases = list()
 
     def getType(self):

--- a/sflib.py
+++ b/sflib.py
@@ -668,7 +668,8 @@ class SpiderFoot:
             if type(opts[opt]) is list:
                 storeopts[opt] = ','.join(opts[opt])
 
-        if opts['__modules__'] is None:
+        # todo: ensure the __modules__ key value is in the expected format
+        if '__modules__' not in opts:
             return storeopts
 
         for mod in opts['__modules__']:
@@ -2773,4 +2774,3 @@ class SpiderFootEvent(object):
 
     def setSourceEventHash(self, srcHash):
         self.sourceEventHash = srcHash
-

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -418,7 +418,7 @@ class SpiderFootWebUi:
             # Start running a new scan
             try:
                 s = SpiderFootScanner(scanname, scantarget, targetType, modlist, cfg)
-                s.getId()
+                scanId = s.getId()
             except BaseException as e:
                 print("[-] Failed to initialize scan: %s" % e)
                 return self.error("Failed to initialize scan: %s" % e)

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -335,7 +335,6 @@ class SpiderFootWebUi:
     def rerunscan(self, id):
         # Snapshot the current configuration to be used by the scan
         cfg = deepcopy(self.config)
-        modopts = dict() # Not used yet as module options are set globally
         modlist = list()
         sf = SpiderFoot(cfg)
         dbh = SpiderFootDb(cfg)
@@ -363,27 +362,35 @@ class SpiderFootWebUi:
             scantarget = scantarget.lower()
 
         # Start running a new scan
-        newId = sf.genScanInstanceGUID(scanname)
-        p = mp.Process(target=SpiderFootScanner, args=(scanname, scantarget, targetType, newId,
-                modlist, cfg, modopts))
-        p.start()
+        try:
+            s = SpiderFootScanner(scanname, scantarget, targetType, modlist, cfg)
+            scanId = s.getId()
+        except BaseException as e:
+            print("[-] Failed to initialize scan: %s" % e)
+            return self.error("Failed to initialize scan: %s" % e)
 
+        try:
+            p = mp.Process(target=s.startScan())
+            p.daemon = True
+            p.start()
+        except BaseException as e:
+            print("[-] Scan [%s] failed: %s" % (scanId, e))
+            return self.error("Scan [%s] failed: %s" % (scanId, e))
 
         # Wait until the scan has initialized
-        while dbh.scanInstanceGet(newId) == None:
+        while dbh.scanInstanceGet(scanId) == None:
             print("[info] Waiting for the scan to initialize...")
             time.sleep(1)
 
         templ = Template(filename='dyn/scaninfo.tmpl', lookup=self.lookup)
-        return templ.render(id=newId, name=str(scanname), docroot=self.docroot,
-            status=dbh.scanInstanceGet(newId), pageid="SCANLIST")
+        return templ.render(id=scanId, name=str(scanname), docroot=self.docroot,
+            status=dbh.scanInstanceGet(scanId), pageid="SCANLIST")
 
     rerunscan.exposed = True
 
     def rerunscanmulti(self, ids):
         # Snapshot the current configuration to be used by the scan
         cfg = deepcopy(self.config)
-        modopts = dict() # Not used yet as module options are set globally
         modlist = list()
         sf = SpiderFoot(cfg)
         dbh = SpiderFootDb(cfg)
@@ -409,13 +416,23 @@ class SpiderFootWebUi:
                                   "a human name, IP address, IP subnet, ASN, domain name or host name.")
 
             # Start running a new scan
-            newId = sf.genScanInstanceGUID(scanname)
-            p = mp.Process(target=SpiderFootScanner, args=(scanname, scantarget.lower(), 
-                            targetType, newId, modlist, cfg, modopts))
-            p.start()
+            try:
+                s = SpiderFootScanner(scanname, scantarget, targetType, modlist, cfg)
+                s.getId()
+            except BaseException as e:
+                print("[-] Failed to initialize scan: %s" % e)
+                return self.error("Failed to initialize scan: %s" % e)
+
+            try:
+                p = mp.Process(target=s.startScan())
+                p.daemon = True
+                p.start()
+            except BaseException as e:
+                print("[-] Scan [%s] failed: %s" % (scanId, e))
+                return self.error("Scan [%s] failed: %s" % (scanId, e))
 
             # Wait until the scan has initialized
-            while dbh.scanInstanceGet(newId) == None:
+            while dbh.scanInstanceGet(scanId) == None:
                 print("[info] Waiting for the scan to initialize...")
                 time.sleep(1)
 
@@ -769,7 +786,6 @@ class SpiderFootWebUi:
 
         # Snapshot the current configuration to be used by the scan
         cfg = deepcopy(self.config)
-        modopts = dict()  # Not used yet as module options are set globally
         modlist = list()
         sf = SpiderFoot(cfg)
         targetType = None
@@ -835,15 +851,25 @@ class SpiderFootWebUi:
             modlist.remove("sfp__stor_stdout")
 
         # Start running a new scan
-        scanId = sf.genScanInstanceGUID(scanname)
         if targetType in [ "HUMAN_NAME", "USERNAME" ]:
             scantarget = scantarget.replace("\"", "")
         else:
             scantarget = scantarget.lower()
-        p = mp.Process(target=SpiderFootScanner, args=(scanname, scantarget, targetType, scanId,
-                              modlist, cfg, modopts))
-        p.daemon = True
-        p.start()
+
+        try:
+            s = SpiderFootScanner(scanname, scantarget, targetType, modlist, cfg)
+            scanId = s.getId()
+        except BaseException as e:
+            print("[-] Failed to initialize scan: %s" % e)
+            return self.error("Failed to initialize scan: %s" % e)
+
+        try:
+            p = mp.Process(target=s.startScan())
+            p.daemon = True
+            p.start()
+        except BaseException as e:
+            print("[-] Scan [%s] failed: %s" % (scanId, e))
+            return self.error("Scan [%s] failed: %s" % (scanId, e))
 
         # Wait until the scan has initialized
         # Check the database for the scan status results

--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -18,8 +18,9 @@ class TestSpiderFoot(unittest.TestCase):
       '_fetchtimeout': 5,  # number of seconds before giving up on a fetch
       '_internettlds': 'https://publicsuffix.org/list/effective_tld_names.dat',
       '_internettlds_cache': 72,
+      '_genericusers': "abuse,admin,billing,compliance,devnull,dns,ftp,hostmaster,inoc,ispfeedback,ispsupport,list-request,list,maildaemon,marketing,noc,no-reply,noreply,null,peering,peering-notify,peering-request,phish,phishing,postmaster,privacy,registrar,registry,root,routing-registry,rr,sales,security,spam,support,sysadmin,tech,undisclosed-recipients,unsubscribe,usenet,uucp,webmaster,www",
       '__version__': '3.0',
-      '__database': 'spiderfoot.db',
+      '__database': 'spiderfoot.test.db',  # note: test database file
       '__webaddr': '127.0.0.1',
       '__webport': 5001,
       '__docroot': '',  # don't put trailing /
@@ -149,11 +150,11 @@ class TestSpiderFoot(unittest.TestCase):
 
     def test_gen_scan_instance_guid_should_return_a_string(self):
         """
-        Test genScanInstanceGUID(self, scanName)
+        Test genScanInstanceGUID(self)
         """
         sf = SpiderFoot(dict())
 
-        scan_instance_id = sf.genScanInstanceGUID(None)
+        scan_instance_id = sf.genScanInstanceGUID()
         self.assertIsInstance(scan_instance_id, str)
 
     def test_dblog_invalid_dbh_should_raise(self):
@@ -266,27 +267,49 @@ class TestSpiderFoot(unittest.TestCase):
         self.assertIsInstance(cache_get, str)
         self.assertEqual(data, cache_get)
 
-    @unittest.skip("todo")
+    def test_config_serialize_invalid_opts_should_raise(self):
+        """
+        Test configSerialize(self, opts, filterSystem=True)
+        """
+        sf = SpiderFoot(dict())
+
+        with self.assertRaises(TypeError) as cm:
+            config = sf.configSerialize(None, None)
+
     def test_config_serialize_should_return_a_dict(self):
         """
         Test configSerialize(self, opts, filterSystem=True)
         """
         sf = SpiderFoot(dict())
 
-        config = sf.configSerialize(None, None)
-        self.assertIsInstance(config, dict)
-
         config = sf.configSerialize(dict(), None)
         self.assertIsInstance(config, dict)
 
-    @unittest.skip("todo")
+    def test_config_unserialize_invalid_opts_should_raise(self):
+        """
+        Test configUnserialize(self, opts, referencePoint, filterSystem=True)
+        """
+        sf = SpiderFoot(dict())
+
+        with self.assertRaises(TypeError) as cm:
+            config = sf.configUnserialize(None, dict(), None)
+
+    def test_config_unserialize_invalid_reference_point_should_raise(self):
+        """
+        Test configUnserialize(self, opts, referencePoint, filterSystem=True)
+        """
+        sf = SpiderFoot(dict())
+
+        with self.assertRaises(TypeError) as cm:
+            config = sf.configUnserialize(dict(), None, None)
+
     def test_config_unserialize_should_return_a_dict(self):
         """
         Test configUnserialize(self, opts, referencePoint, filterSystem=True)
         """
         sf = SpiderFoot(dict())
 
-        config = sf.configUnserialize(None, None, None)
+        config = sf.configUnserialize(dict(), dict(), True)
         self.assertIsInstance(config, dict)
 
     def test_cache_get_invalid_label_should_return_none(self):

--- a/test/unit/test_spiderfootdb.py
+++ b/test/unit/test_spiderfootdb.py
@@ -17,6 +17,7 @@ class TestSpiderFootDb(unittest.TestCase):
       '_fetchtimeout': 5,
       '_internettlds': 'https://publicsuffix.org/list/effective_tld_names.dat',
       '_internettlds_cache': 72,
+      '_genericusers': "abuse,admin,billing,compliance,devnull,dns,ftp,hostmaster,inoc,ispfeedback,ispsupport,list-request,list,maildaemon,marketing,noc,no-reply,noreply,null,peering,peering-notify,peering-request,phish,phishing,postmaster,privacy,registrar,registry,root,routing-registry,rr,sales,security,spam,support,sysadmin,tech,undisclosed-recipients,unsubscribe,usenet,uucp,webmaster,www",
       '__version__': '3.0',
       '__database': 'spiderfoot.test.db',  # note: test database file
       '__webaddr': '127.0.0.1',

--- a/test/unit/test_spiderfootscanner.py
+++ b/test/unit/test_spiderfootscanner.py
@@ -2,49 +2,105 @@
 from sfscan import SpiderFootScanner
 import unittest
 
-class TestSpiderFootScanStatus(unittest.TestCase):
+class TestSpiderFootScanner(unittest.TestCase):
     """
     Test SpiderFootScanStatus
     """
+    default_options = {
+      '_debug': False,
+      '__logging': True,
+      '__outputfilter': None,
+      '__blocknotif': False,
+      '_fatalerrors': False,
+      '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',
+      '_dnsserver': '',
+      '_fetchtimeout': 5,
+      '_internettlds': 'https://publicsuffix.org/list/effective_tld_names.dat',
+      '_internettlds_cache': 72,
+      '_genericusers': "abuse,admin,billing,compliance,devnull,dns,ftp,hostmaster,inoc,ispfeedback,ispsupport,list-request,list,maildaemon,marketing,noc,no-reply,noreply,null,peering,peering-notify,peering-request,phish,phishing,postmaster,privacy,registrar,registry,root,routing-registry,rr,sales,security,spam,support,sysadmin,tech,undisclosed-recipients,unsubscribe,usenet,uucp,webmaster,www",
+      '__version__': '3.0',
+      '__database': 'spiderfoot.test.db',  # note: test database file
+      '__webaddr': '127.0.0.1',
+      '__webport': 5001,
+      '__docroot': '',
+      '__modules__': None,
+      '_socks1type': '',
+      '_socks2addr': '',
+      '_socks3port': '',
+      '_socks4user': '',
+      '_socks5pwd': '',
+      '_socks6dns': True,
+      '_torctlport': 9051,
+      '__logstdout': False
+    }
 
-    def test_init_no_options_should_raise(self):
-        """
-        Test __init__(self, scanName, scanTarget, targetType, scanId, moduleList, globalOpts, moduleOpts)
-        """
-        with self.assertRaises(TypeError) as cm:
-            sfscan = SpiderFootScanner(None, None, None, None, None, None, None)
-  
-    @unittest.skip("todo")
     def test_init(self):
         """
-        Test __init__(self, scanName, scanTarget, targetType, scanId, moduleList, globalOpts, moduleOpts)
+        Test __init__(self, scanName, scanTarget, targetType, moduleList, globalOpts)
         """
-        #sfscan = SpiderFootScanner("", "", "", "", list(), dict(), dict())
-        self.assertEqual('TBD', 'TBD')
+        sfscan = SpiderFootScanner("", "", "IP_ADDRESS", list(), self.default_options)
+        self.assertIsInstance(sfscan, SpiderFootScanner)
 
-    @unittest.skip("todo")
-    def test_set_status_should_return_none(self):
+    def test_init_invalid_scan_name_should_raise(self):
+        """
+        Test __init__(self, scanName, scanTarget, targetType, moduleList, globalOpts)
+        """
+        with self.assertRaises(TypeError) as cm:
+            sfscan = SpiderFootScanner(None, "", "IP_ADDRESS", list(), self.default_options)
+
+    def test_init_invalid_scan_target_should_raise(self):
+        """
+        Test __init__(self, scanName, scanTarget, targetType, moduleList, globalOpts)
+        """
+        with self.assertRaises(TypeError) as cm:
+            sfscan = SpiderFootScanner("", None, "IP_ADDRESS", list(), self.default_options)
+
+    def test_init_invalid_scan_target_type_should_raise(self):
+        """
+        Test __init__(self, scanName, scanTarget, targetType, moduleList, globalOpts)
+        """
+        with self.assertRaises(TypeError) as cm:
+            sfscan = SpiderFootScanner("", "", None, list(), self.default_options)
+
+    def test_init_invalid_module_list_should_raise(self):
+        """
+        Test __init__(self, scanName, scanTarget, targetType, moduleList, globalOpts)
+        """
+        with self.assertRaises(TypeError) as cm:
+            sfscan = SpiderFootScanner("", "", "IP_ADDRESS", None, self.default_options)
+
+    def test_init_invalid_options_should_raise(self):
+        """
+        Test __init__(self, scanName, scanTarget, targetType, moduleList, globalOpts)
+        """
+        with self.assertRaises(TypeError) as cm:
+            sfscan = SpiderFootScanner("", "", "IP_ADDRESS", list(), None)
+
+        with self.assertRaises(ValueError) as cm:
+            sfscan = SpiderFootScanner("", "", "IP_ADDRESS", list(), dict())
+
+    def test_set_status_invalid_status_should_raise(self):
         """
         Test def setStatus(self, status, started=None, ended=None)
         """
-        self.assertEqual('TBD', 'TBD')
+        sfscan = SpiderFootScanner("", "", "IP_ADDRESS", list(), self.default_options)
+        self.assertIsInstance(sfscan, SpiderFootScanner)
 
-    @unittest.skip("todo")
-    def test_run_should_return_none(self):
-        """
-        Test def run(self)
-        """
-        self.assertEqual('TBD', 'TBD')
+        with self.assertRaises(ValueError) as cm:
+            sfscan.setStatus("invalid status", None, None)
 
-    @unittest.skip("todo")
-    def test_get_id_should_return_none(self):
+    def test_get_id_should_return_a_scan_id(self):
         """
         Test def getId(self)
         """
-        self.assertEqual('TBD', 'TBD')
+        sfscan = SpiderFootScanner("", "", "IP_ADDRESS", list(), self.default_options)
+        self.assertIsInstance(sfscan, SpiderFootScanner)
+
+        scan_id = sfscan.getId()
+        self.assertIsInstance(scan_id, str)
 
     @unittest.skip("todo")
-    def test_start_scan_should_return_none(self):
+    def test_start_scan_should_start_a_scan(self):
         """
         Test def startScan(self)
         """

--- a/test/unit/test_spiderfoottarget.py
+++ b/test/unit/test_spiderfoottarget.py
@@ -12,15 +12,19 @@ class TestSpiderFootTarget(unittest.TestCase):
         'EMAILADDR', 'HUMAN_NAME', 'BGP_AS_OWNER', 'PHONE_NUMBER', "USERNAME"
     ]
 
+    def test_init_invalid_target_value_should_raise(self):
+        """
+        Test __init__(self, targetValue, typeName)
+        """
+        with self.assertRaises(TypeError) as cm:
+            target = SpiderFootTarget(None, 'IP_ADDRESS')
+
     def test_init_unsupported_target_type_should_raise(self):
         """
         Test __init__(self, targetValue, typeName)
         """
-        target_value = 'example target value'
-
         with self.assertRaises(ValueError) as cm:
-            target_type = 'example target type'
-            target = SpiderFootTarget(target_value, target_type)
+            target = SpiderFootTarget('example target value', 'example target type')
 
     def test_init_supported_target_types(self):
         """

--- a/test/unit/test_spiderfootwebui.py
+++ b/test/unit/test_spiderfootwebui.py
@@ -17,6 +17,7 @@ class TestSpiderFootWebUi(unittest.TestCase):
       '_fetchtimeout': 5,
       '_internettlds': 'https://publicsuffix.org/list/effective_tld_names.dat',
       '_internettlds_cache': 72,
+      '_genericusers': "abuse,admin,billing,compliance,devnull,dns,ftp,hostmaster,inoc,ispfeedback,ispsupport,list-request,list,maildaemon,marketing,noc,no-reply,noreply,null,peering,peering-notify,peering-request,phish,phishing,postmaster,privacy,registrar,registry,root,routing-registry,rr,sales,security,spam,support,sysadmin,tech,undisclosed-recipients,unsubscribe,usenet,uucp,webmaster,www",
       '__version__': '3.0',
       '__database': 'spiderfoot.test.db',  # note: test database file
       '__webaddr': '127.0.0.1',


### PR DESCRIPTION
This should also fix #554 by ensuring scan IDs are automatically generated.
