### PR TITLE
sflib: cleanup parseIBANNumbers function

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -1692,24 +1692,24 @@ class SpiderFoot:
         return list(creditCards)
         
     def parseIBANNumbers(self, data):
-        """Find all IBAN numbers with the supplied content.
+        """Find all International Bank Account Numbers (IBANs) within the supplied content.
 
-        Extracts possible IBAN Numbers using a generic regex.
+        Extracts possible IBANs using a generic regex.
 
-        Checks whether the possible IBAN number is valid or not
-        Using country-wise length check and Mod 97 algorithm.
+        Checks whether possible IBANs are valid or not
+        using country-wise length check and Mod 97 algorithm.
 
         Args:
-            data (str): text to search for credit card numbers
+            data (str): text to search for IBANs
 
         Returns:
-            list: list of credit card numbers
+            list: list of IBAN
         """
 
         if not isinstance(data, str):
             return list()
 
-        ibanNumbers = set()
+        ibans = set()
 
         # Dictionary of country codes and their respective IBAN lengths
         ibanCountryLengths = {
@@ -1721,7 +1721,7 @@ class SpiderFoot:
             "FI" : 18, "FR" : 27, "GE" : 22, "DE" : 22,
             "GI" : 23, "GR" : 27, "GL" : 18, "GT" : 28,
             "VA" : 22, "HU" : 28, "IS" : 26, "IQ" : 23,
-            "IE" : 22, "IL" : 27, "JO" : 30, "KZ" : 20,
+            "IE" : 22, "IL" : 23, "JO" : 30, "KZ" : 20,
             "XK" : 20, "KW" : 30, "LV" : 21, "LB" : 28,
             "LI" : 21, "LT" : 20, "LU" : 20, "MT" : 31,
             "MR" : 27, "MU" : 30, "MD" : 24, "MC" : 27,
@@ -1739,52 +1739,46 @@ class SpiderFoot:
             "AE" : 23, "GB" : 22, "SE" : 24
         }
 
-        # Remove whitespace from data. 
-        # IBAN Numbers might contain spaces between them 
-        # which will cause regex mismatch
+        # Normalize input data to remove whitespace
         data = data.replace(" ", "")
 
-        # Extract alphanumeric characters of lengths ranging from 16 to 31
-        possibleIBANRegex = "[A-Za-z0-9]{16,31}"
-        matches = re.findall(possibleIBANRegex, data)
+        # Extract alphanumeric characters of lengths ranging from 15 to 32
+        # and starting with two characters
+        matches = re.findall("[A-Za-z]{2}[A-Za-z0-9]{13,30}", data)
 
         for match in matches:  
-            match = match.upper()
-            ibanNumber = match
+            iban = match.upper()
 
-            countryCode = ibanNumber[0:2]
+            countryCode = iban[0:2]
 
             if countryCode not in ibanCountryLengths.keys():
-                # Invalid IBAN Number due to country code not existing in dictionary
-                self.debug("Skipped invalid IBAN number: " + ibanNumber)
+                # Invalid IBAN due to country code not existing in dictionary
+                self.debug("Skipped invalid IBAN: %s" % iban)
                 continue
             
-            # Using Mod 97 algorithm to verify if IBAN Number is valid
-            if len(ibanNumber) == ibanCountryLengths[countryCode]:
-                # Move the first 4 characters to the end of the string 
-                match = match[4:] + match[0:4]  
-                
-                for character in match: 
-                    # Check if character is a letter
-                    if character.isalpha():
-                        # Replace letters to number  
-                        # where A = 10, B = 11, ...., Z = 35
-                        match = match.replace(character, str((ord(character) - 65) + 10))                     
-
-                if int(match) % 97 == 1:
-                    # IBAN Number is valid 
-                    self.debug("Found IBAN number: " + match)
-                    ibanNumbers.add(ibanNumber)
-                else:
-                    # Invalid IBAN Number due to failed Mod 97 operation
-                    self.debug("Skipped invalid IBAN number: " + ibanNumber)
-                    continue                    
-            else:
-                # Invalid IBAN Number due to length mismatch
-                self.debug("Skipped invalid IBAN number: " + ibanNumber)
+            if len(iban) != ibanCountryLengths[countryCode]:
+                # Invalid IBAN due to length mismatch
+                self.debug("Skipped invalid IBAN: %s" % iban)
                 continue
 
-        return list(ibanNumbers)
+            # Convert IBAN to integer format.
+            # Move the first 4 characters to the end of the string,
+            # then convert all characters to integers; where A = 10, B = 11, ...., Z = 35
+            iban_int = iban[4:] + iban[0:4]
+            for character in iban_int:
+                if character.isalpha():
+                    iban_int = iban_int.replace(character, str((ord(character) - 65) + 10))
+
+            # Check IBAN integer mod 97 for remainder
+            if int(iban_int) % 97 != 1:
+                # Invalid IBAN due to failed Mod 97 operation
+                self.debug("Skipped invalid IBAN: %s" % iban)
+                continue
+
+            self.debug("Found IBAN: %s" % iban)
+            ibans.add(iban)
+
+        return list(ibans)
 
     def sslDerToPem(self, der_cert):
         """Given a certificate as a DER-encoded blob of bytes, returns a PEM-encoded string version of the same certificate.

--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -1014,11 +1014,106 @@ class TestSpiderFoot(unittest.TestCase):
                 ibans = sf.parseIBANNumbers(invalid_type)
                 self.assertIsInstance(ibans, list)
 
-        ibans = sf.parseCreditCards("spiderfootAL35202111090000000001234567spiderfootAD1400080001001234567890spiderfootAT483200000012345864spiderfoot")
-        self.assertIsInstance(ibans, list)
-        #self.assertIn("AL35202111090000000001234567", ibans)
-        #self.assertIn("AD1400080001001234567890", ibans)
-        #self.assertIn("AT483200000012345864", ibans)
+        # Example IBANS from https://www.iban.com/structure
+        ibans = [
+            "AL35202111090000000001234567",
+            "AD1400080001001234567890",
+            "AT483200000012345864",
+            "AZ96AZEJ00000000001234567890",
+            "BH02CITI00001077181611",
+            "BY86AKBB10100000002966000000",
+            "BE71096123456769",
+            "BA393385804800211234",
+            "BR1500000000000010932840814P2",
+            "BG18RZBB91550123456789",
+            "CR23015108410026012345",
+            "HR1723600001101234565",
+            "CY21002001950000357001234567",
+            "CZ5508000000001234567899",
+            "DK9520000123456789",
+            "DO22ACAU00000000000123456789",
+            "EG800002000156789012345180002",
+            "SV43ACAT00000000000000123123",
+            "EE471000001020145685",
+            "FO9264600123456789",
+            "FI1410093000123458",
+            "FR7630006000011234567890189",
+            "GE60NB0000000123456789",
+            "DE75512108001245126199",
+            "GI04BARC000001234567890",
+            "GR9608100010000001234567890",
+            "GL8964710123456789",
+            "GT20AGRO00000000001234567890",
+            "VA59001123000012345678",
+            "HU93116000060000000012345676",
+            "IS750001121234563108962099",
+            "IQ20CBIQ861800101010500",
+            "IE64IRCE92050112345678",
+            "IL170108000000012612345",
+            "IT60X0542811101000000123456",
+            "JO71CBJO0000000000001234567890",
+            "KZ563190000012344567",
+            "XK051212012345678906",
+            "KW81CBKU0000000000001234560101",
+            "LV97HABA0012345678910",
+            "LB92000700000000123123456123",
+            "LI7408806123456789012",
+            "LT601010012345678901",
+            "LU120010001234567891",
+            "MT31MALT01100000000000000000123",
+            "MR1300020001010000123456753",
+            "MU43BOMM0101123456789101000MUR",
+            "MD21EX000000000001234567",
+            "MC5810096180790123456789085",
+            "ME25505000012345678951",
+            "NL02ABNA0123456789",
+            "MK07200002785123453",
+            "NO8330001234567",
+            "PK36SCBL0000001123456702",
+            "PS92PALS000000000400123456702",
+            "PL10105000997603123456789123",
+            "PT50002700000001234567833",
+            "QA54QNBA000000000000693123456",
+            "RO09BCYP0000001234567890",
+            "LC14BOSL123456789012345678901234",
+            "SM76P0854009812123456789123",
+            "ST23000200000289355710148",
+            "SA4420000001234567891234",
+            "RS35105008123123123173",
+            "SC52BAHL01031234567890123456USD",
+            "SK8975000000000012345671",
+            "SI56192001234567892",
+            "ES7921000813610123456789",
+            "SE7280000810340009783242",
+            "CH5604835012345678009",
+            "TL380010012345678910106",
+            "TN5904018104004942712345",
+            "TR320010009999901234567890",
+            "UA903052992990004149123456789",
+            "AE460090000000123456789",
+            "GB33BUKB20201555555555",
+            "VG21PACG0000000123456789"
+        ]
+        for iban in ibans:
+            with self.subTest(iban=iban):
+                parse_ibans = sf.parseIBANNumbers(iban)
+                self.assertIsInstance(parse_ibans, list)
+                self.assertIn(iban, parse_ibans)
+
+        # Invalid IBANs
+        ibans = [
+            # Invalid country code
+            "ZZ21PACG0000000123456789",
+            # Invalid length for country code
+            "VG123456789012345",
+            # Invalid mod 97 remainder
+            "VG21PACG0000000123456111"
+        ]
+        for iban in ibans:
+            with self.subTest(iban=iban):
+                parse_ibans = sf.parseIBANNumbers(iban)
+                self.assertIsInstance(parse_ibans, list)
+                self.assertNotIn(iban, parse_ibans)
 
     def test_parse_emails_should_return_list_of_emails_from_string(self):
         """


### PR DESCRIPTION
Clean up `parseIBANNumbers` code; change expected length from `27` to `23` for `IL` country code; fix `parseIBANNumbers` tests.
