### PR TITLE
SpiderFootTarget: use Python property decorators

### DIFF
--- a/modules/sfp_dnsresolve.py
+++ b/modules/sfp_dnsresolve.py
@@ -72,11 +72,11 @@ class sfp_dnsresolve(SpiderFootPlugin):
                 # If the target was a hostname/sub-domain, we can
                 # add the domain as an alias for the target. But
                 # not if the target was an IP or subnet.
-                #if target.getType() == "INTERNET_NAME":
+                #if target.targetType == "INTERNET_NAME":
                 #    dom = self.sf.hostDomain(host, self.opts['_internettlds'])
                 #    target.setAlias(dom, "INTERNET_NAME")
 
-        self.sf.info("Aliases identified: " + str(target.getAliases()))
+        self.sf.info("Aliases identified: " + str(target.targetAliases))
 
         return target
 

--- a/sflib.py
+++ b/sflib.py
@@ -1511,8 +1511,8 @@ class SpiderFoot:
         if not target:
             return ret
 
-        t = target.getType()
-        v = target.getValue()
+        t = target.targetType
+        v = target.targetValue
 
         if t in [ "IP_ADDRESS", "IPV6_ADDRESS" ]:
             r = self.resolveIP(v)
@@ -2507,7 +2507,7 @@ class SpiderFootPlugin(object):
         if self.__outputFilter__:
             # Be strict about what events to pass on, unless they are
             # the ROOT event or the event type of the target.
-            if eventName != 'ROOT' and eventName != self.getTarget().getType() \
+            if eventName != 'ROOT' and eventName != self.getTarget().targetType \
                 and eventName not in self.__outputFilter__:
                 return None
 
@@ -2645,9 +2645,9 @@ class SpiderFootTarget(object):
 
     _validTypes = ["IP_ADDRESS", 'IPV6_ADDRESS', "NETBLOCK_OWNER", "INTERNET_NAME",
                    "EMAILADDR", "HUMAN_NAME", "BGP_AS_OWNER", 'PHONE_NUMBER', "USERNAME"]
-    targetType = None
-    targetValue = None
-    targetAliases = list()
+    _targetType = None
+    _targetValue = None
+    _targetAliases = list()
 
     def __init__(self, targetValue, typeName):
         """Initialize SpiderFoot target.
@@ -2669,15 +2669,33 @@ class SpiderFootTarget(object):
         if typeName not in self._validTypes:
             raise ValueError("Invalid target type %s; expected %s" % (typeName, self._validTypes))
 
-        self.targetType = typeName
-        self.targetValue = targetValue
-        self.targetAliases = list()
+        self._targetType = typeName
+        self._targetValue = targetValue
+        self._targetAliases = list()
 
-    def getType(self):
-        return self.targetType
+    @property
+    def targetType(self):
+        return self._targetType
 
-    def getValue(self):
-        return self.targetValue
+    @targetType.setter
+    def targetType(self, value):
+        self._targetType = value
+
+    @property
+    def targetValue(self):
+        return self._targetValue
+
+    @targetValue.setter
+    def targetValue(self, value):
+        self._targetValue = value
+
+    @property
+    def targetAliases(self):
+        return self._targetAliases
+
+    @targetAliases.setter
+    def targetAliases(self, value):
+        self._targetAliases = value
 
     def setAlias(self, value, typeName):
         """Specify other hostnames, IPs, etc. that are aliases for this target.
@@ -2704,15 +2722,6 @@ class SpiderFootTarget(object):
         self.targetAliases.append(
             {'type': typeName, 'value': value.lower()}
         )
-
-    def getAliases(self):
-        """TBD
-
-        Returns:
-            list: target aliases
-        """
-
-        return self.targetAliases
 
     def _getEquivalents(self, typeName):
         """TBD

--- a/test/unit/test_spiderfoottarget.py
+++ b/test/unit/test_spiderfoottarget.py
@@ -36,8 +36,8 @@ class TestSpiderFootTarget(unittest.TestCase):
             with self.subTest(target_type=target_type):
                 target = SpiderFootTarget(target_value, target_type)
                 self.assertEqual(SpiderFootTarget, type(target))
-                self.assertEqual(target.getType(), target_type)
-                self.assertEqual(target.getValue(), target_value)
+                self.assertEqual(target.targetType, target_type)
+                self.assertEqual(target.targetValue, target_value)
 
     def test_set_alias(self):
         """
@@ -50,16 +50,37 @@ class TestSpiderFootTarget(unittest.TestCase):
         set_alias = target.setAlias(None, None)
         self.assertEqual('TBD', 'TBD')
 
-    def test_get_aliases_should_return_a_list(self):
+    def test_target_type_attribute_should_return_a_string(self):
         """
-        Test getAliases(self)
+        Test targetType attribute
         """
         target_value = 'example target value'
         target_type = 'IP_ADDRESS'
         target = SpiderFootTarget(target_value, target_type)
 
-        aliases = target.getAliases()
-        self.assertEqual(list, type(aliases))
+        self.assertIsInstance(target.targetType, str)
+        self.assertEqual(target_type, target.targetType)
+
+    def test_target_value_attribute_should_return_a_string(self):
+        """
+        Test targetValue attribute
+        """
+        target_value = 'example target value'
+        target_type = 'IP_ADDRESS'
+        target = SpiderFootTarget(target_value, target_type)
+
+        self.assertIsInstance(target.targetValue, str)
+        self.assertEqual(target_value, target.targetValue)
+
+    def test_target_aliases_attribute_should_return_a_list(self):
+        """
+        Test targetAliases attribute
+        """
+        target_value = 'example target value'
+        target_type = 'IP_ADDRESS'
+        target = SpiderFootTarget(target_value, target_type)
+
+        self.assertIsInstance(target.targetAliases, list)
 
     def test_get_equivalents_should_return_a_list(self):
         """


### PR DESCRIPTION
Use Python property decorators rather than setter/getter functions
for target type/value/aliases.