### PR TITLE
SpiderFootDb: validate result hash IDs

### DIFF
--- a/sfdb.py
+++ b/sfdb.py
@@ -1162,6 +1162,14 @@ class SpiderFootDb:
         if not isinstance(elementIdList, list):
             raise TypeError("elementIdList is %s; expected list()" % type(elementIdList))
 
+        hashIds = []
+        for hashId in elementIdList:
+            if not hashId:
+                continue
+            if not hashId.isalnum():
+                continue
+            hashIds.append(hashId)
+
         # the output of this needs to be aligned with scanResultEvent,
         # as other functions call both expecting the same output.
         qry = "SELECT ROUND(c.generated) AS generated, c.data, \
@@ -1172,12 +1180,8 @@ class SpiderFootDb:
             FROM tbl_scan_results c, tbl_scan_results s, tbl_event_types t \
             WHERE c.scan_instance_id = ? AND c.source_event_hash = s.hash AND \
             s.scan_instance_id = c.scan_instance_id AND \
-            t.event = c.type AND c.hash in ("
+            t.event = c.type AND c.hash in ('%s')" % "','".join(hashIds)
         qvars = [instanceId]
-
-        for hashId in elementIdList:
-            qry = qry + "'" + hashId + "',"
-        qry += "'')"
 
         with self.dbhLock:
             try:
@@ -1204,6 +1208,14 @@ class SpiderFootDb:
         if not isinstance(elementIdList, list):
             raise TypeError("elementIdList is %s; expected list()" % type(elementIdList))
 
+        hashIds = []
+        for hashId in elementIdList:
+            if not hashId:
+                continue
+            if not hashId.isalnum():
+                continue
+            hashIds.append(hashId)
+
         # the output of this needs to be aligned with scanResultEvent,
         # as other functions call both expecting the same output.
         qry = "SELECT ROUND(c.generated) AS generated, c.data, \
@@ -1214,12 +1226,8 @@ class SpiderFootDb:
             FROM tbl_scan_results c, tbl_scan_results s, tbl_event_types t \
             WHERE c.scan_instance_id = ? AND c.source_event_hash = s.hash AND \
             s.scan_instance_id = c.scan_instance_id AND \
-            t.event = c.type AND s.hash in ("
+            t.event = c.type AND s.hash in ('%s')" % "','".join(hashIds)
         qvars = [instanceId]
-
-        for hashId in elementIdList:
-            qry = qry + "'" + hashId + "',"
-        qry += "'')"
 
         with self.dbhLock:
             try:

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -736,6 +736,9 @@ class SpiderFootWebUi:
 
         # Cannot set FPs if a scan is not completed
         status = dbh.scanInstanceGet(id)
+        if not status:
+            return self.error("Invalid scan ID: %s" % id)
+
         if status[5] not in [ "ABORTED", "FINISHED", "ERROR-FAILED" ]:
             return json.dumps(["WARNING", "Scan must be in a finished state when " + \
                                "setting False Positives."])
@@ -931,9 +934,8 @@ class SpiderFootWebUi:
         for id in ids.split(","):
             errState = False
             scaninfo = dbh.scanInstanceGet(id)
-
-            if scaninfo is None:
-                return self.error("Invalid scan ID specified.")
+            if not scaninfo:
+                return self.error("Invalid scan ID: %s" % id)
 
             scanname = str(scaninfo[0])
             scanstatus = scaninfo[5]


### PR DESCRIPTION
Validate result hash IDs in the `SpiderFootDb.scanElementSourcesDirect` and `SpiderFootDb.scanElementChildrenDirect`  functions.

This prevents blind SQL injection via the `/resultsetfp` route (and perhaps some others - whatever calls the aforementioned functions).

Proof of concept below. Note that the provided scan Id (`id` parameter) must be valid (for any scan).

```
curl 'http://127.0.0.1:5001/resultsetfp' --data-raw "id=5B9F4408&fp=1&resultids=%5B%229ea067b595f237c2eabff3653cda0c77eef786b6794e38a086b13dbf0463201a%22,%22') union select '1','2','3','4','5','6','7','8','9','10','11','12','13','14','15'%3b--a%22%5D"
```
