### PR TITLE
sflib: Ensure checkForStop() returns false when no scan ID is set

### DIFF
--- a/sfdb.py
+++ b/sfdb.py
@@ -1115,7 +1115,7 @@ class SpiderFootDb:
         if not sfEvent.data:
             raise ValueError("sfEvent.data is empty")
 
-        if not isinstance(sfEvent.sourceEventhash, str):
+        if not isinstance(sfEvent.sourceEventHash, str):
             raise TypeError("sfEvent.sourceEventHash is %s; expected str()" % type(sfEvent.sourceEventHash))
 
         if not sfEvent.sourceEventHash:

--- a/sflib.py
+++ b/sflib.py
@@ -2594,11 +2594,17 @@ class SpiderFootPlugin(object):
         Returns:
             bool
         """
+        if not self.__scanId__:
+            return False
 
         scanstatus = self.__sfdb__.scanInstanceGet(self.__scanId__)
-        if scanstatus != None:              
-            if scanstatus[5] == "ABORT-REQUESTED":
-                return True
+
+        if not scanstatus:
+            return False
+
+        if scanstatus[5] == "ABORT-REQUESTED":
+            return True
+
         return False
 
     def watchedEvents(self):

--- a/test/unit/test_spiderfootplugin.py
+++ b/test/unit/test_spiderfootplugin.py
@@ -251,6 +251,7 @@ class TestSpiderFootPlugin(unittest.TestCase):
                 return [None, None, None, None, None, status]
 
         sfp.__sfdb__ = DatabaseStub()
+        sfp.__scanId__ = 'example scan id'
 
         # pseudo-parameterized test
         for status, expectedReturnValue in [("RUNNING", False), ("ABORT-REQUESTED", True)]:


### PR DESCRIPTION
Fix #634 introduced in c3aaf63d0aee209c88df011655dc96c9509c3dac