### PR TITLE
sf: Fix JSON output formatting when running sf from command line

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -373,7 +373,7 @@ if __name__ == '__main__':
                     print('{0:30}{1}{2:45}{3}{4}{5}{6}'.format("Source", delim, "Type", delim, "Source Data", delim, "Data"))
 
         if args.o == "json":
-            print("[", end='')
+            print("[")
 
         while True:
             info = dbh.scanInstanceGet(scanId)


### PR DESCRIPTION
Obviously having a new line after `[` is not ideal, but I'm not sure how else to fix this? Especially if both Windows and *nix need to be supported.

Fix #636
