### PR TITLE
sf: Fix JSON output formatting when running sf from command line

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -339,6 +339,9 @@ if __name__ == '__main__':
         if args.x and args.t:
             cfg['__outputfilter'] = args.t.split(",")
 
+        if args.o == "json":
+            print("[", end='')
+
         # Start running a new scan
         scanName = target
         scanId = sf.genScanInstanceGUID()
@@ -371,9 +374,6 @@ if __name__ == '__main__':
                     print('{0}{1}{2}{3}{4}{5}{6}'.format("Source", delim, "Type", delim, "Source Data", delim, "Data"))
                 else:
                     print('{0:30}{1}{2:45}{3}{4}{5}{6}'.format("Source", delim, "Type", delim, "Source Data", delim, "Data"))
-
-        if args.o == "json":
-            print("[", end='')
 
         while True:
             info = dbh.scanInstanceGet(scanId)


### PR DESCRIPTION
This isn't ideal, as the `[` is printed even when the scan fails due to an error.

Fix #636