### PR TITLE
sfwebui: modify scan info search button to pull right

### DIFF
--- a/dyn/scaninfo.tmpl
+++ b/dyn/scaninfo.tmpl
@@ -1,7 +1,7 @@
 ## -*- coding: utf-8 -*-
 <%include file="HEADER.tmpl"/>
 <h2>${name} &nbsp;<img id="loader" src="${docroot}/static/img/loader.gif"></h2>
-  <div class="btn-toolbar" style='padding-bottom: 10px'>
+  <div class="btn-toolbar" role="toolbar" style='padding-bottom: 10px'>
    <div class="btn-group">
       <a id='btn-status' class="btn btn-default" onClick='scanStatusView("${id}")'><i class='glyphicon glyphicon-eye-open'></i>&nbsp;Status</a>
       <a id='btn-browse' class="btn btn-default" onClick='browseEventList("${id}")'><i class='glyphicon glyphicon-th-list'></i>&nbsp;Browse</a>
@@ -9,17 +9,17 @@
       <a id='btn-info' class="btn btn-default" onClick='viewScanConfig("${id}")'><i class='glyphicon glyphicon-cog'></i>&nbsp;Scan Settings</a>
       <a id='btn-log' class="btn btn-default" onClick='viewScanLog("${id}")'><i class='glyphicon glyphicon-book'></i>&nbsp;Log</a>
     </div>
-    <div id='btn-search' class='btn-group pull-right input-append'>
-    <input class=span2 id=searchvalue type=text placeholder='Search...' data-toggle='popover' data-html=true data-animation=true data-title='Usage' data-content="Supply a regular expression encapsulated in '/', e.g. <i>/searchregex/</i> or a simple wildcard search, e.g. <i>*string*</i> or an exact value, e.g. <i>string</i>.<br><br><b>Note</b> that the current scope is what's searched."> 
-        <button class='btn btn-primary' id=searchbutton type=button onClick=$('#btn-search').popover('toggle');searchDirector('${id}')>
-            <i class='glyphicon glyphicon-search glyphicon glyphicon-white'></i>
-        </button>
+    <div id='btn-search' role="group" class='pull-right input-group'>
+      <input class='pull-left' id='searchvalue' type='text' placeholder='Search...' data-toggle='popover' data-html='true' data-animation='true' data-title='Usage' data-content="Supply a regular expression encapsulated in '/', e.g. <i>/searchregex/</i> or a simple wildcard search, e.g. <i>*string*</i> or an exact value, e.g. <i>string</i>.<br><br><b>Note</b> that the current scope is what's searched.">
+      <button class='btn btn-primary input-group-append' id='searchbutton' type='button' onClick="$('#btn-search').popover('toggle');searchDirector('${id}')">
+        <i class='glyphicon glyphicon-search glyphicon glyphicon-white'></i>
+      </button>
     </div>
-    <div class="btn-group pull-right">
+    <div class="btn-group pull-right" role="group">
     <a id='btn-refresh' rel="tooltip" title="Refresh" class="btn-success btn btn-default" onClick='refresh()'><i class='glyphicon glyphicon-refresh glyphicon glyphicon-white'></i></a>
     <a id='btn-export' rel="tooltip" title="Export Data" class="btn-success btn btn-default" onClick='exportEventData("${id}", currentType)'><i class='glyphicon glyphicon-download-alt glyphicon glyphicon-white'></i></a>
     </div> 
-    <div id='customtabview' class="btn-group pull-right">
+    <div id='customtabview' role="group" class="btn-group pull-right">
      <a id='btn-fullview' rel="tooltip" data-title="Full Data View" class="btn btn-default active" onClick='browseUpdate("full")'><i class='glyphicon glyphicon-th glyphicon glyphicon-white'></i></a>
      <a id='btn-uniqueview' rel="tooltip" data-title="Unique Data View" class="btn btn-default" onClick='browseUpdate("unique")'><i class='glyphicon glyphicon-align-justify glyphicon glyphicon-white'></i></a>
      <a id='btn-vizview' rel="tooltip" data-title="Visualize" class="btn btn-default dropdown-toggle" data-toggle="dropdown"><i class='glyphicon glyphicon-picture glyphicon glyphicon-white'></i></a>
@@ -34,7 +34,7 @@
      <a id='btn-forceatlas' rel="tooltip" data-title="Force Layout" class="btn btn-default" onClick='vizUpdate("force")'><b>F</b></a>
      <a id='btn-saveimage' rel="tooltip" data-title="Save Image" class="btn btn-default dropdown-toggle" onClick='vizUpdate("download")'><i class='glyphicon glyphicon-picture glyphicon glyphicon-white'></i></a>
     </div>
-    <div id='modifyactions' class="btn-group pull-right">
+    <div id='modifyactions' role="group" class="btn-group pull-right">
         <a id='btn-setfp' rel="tooltip" data-title="Set/Unset False Positive flag" class="btn-warning btn btn-default dropdown-toggle" data-toggle="dropdown"><i class='glyphicon glyphicon-ban-circle glyphicon glyphicon-white'></i></a>
         <ul class="dropdown-menu">
             <li><a href='#' class='link' onClick='setFp(1)'>Set False Positive flag</a></li>


### PR DESCRIPTION
Make this:

![Scan Info Search](https://user-images.githubusercontent.com/434827/88906646-08587480-d29b-11ea-9255-0dcf457065e3.png)

Look like this:

![Scan Info Search](https://user-images.githubusercontent.com/434827/88906737-232ae900-d29b-11ea-9e4e-486f50f82d50.png)
