### PR TITLE
sfwebui: change CSS class alert-error to alert-danger

### DIFF
--- a/dyn/error.tmpl
+++ b/dyn/error.tmpl
@@ -1,5 +1,5 @@
 <%include file="HEADER.tmpl"/>
-<div class="alert alert-error">
+<div class="alert alert-danger">
 <h4>${message}</h4>
 <br><br>
 Please go back and try again. If you're pretty sure this is a bug, please <a href='mailto:support@spiderfoot.io'>contact us</a>

--- a/dyn/scandelete.tmpl
+++ b/dyn/scandelete.tmpl
@@ -1,5 +1,5 @@
 <%include file="HEADER.tmpl"/>
-<div class="alert alert-error">
+<div class="alert alert-danger">
 <h4>Confirm Deletion</h4>
 <br>
 % if id != None:


### PR DESCRIPTION
Make error page messages like this:

![before](https://user-images.githubusercontent.com/434827/89104095-08eb3980-d45a-11ea-9e22-eceb9aa2f3d4.png)

Look like this:

![after](https://user-images.githubusercontent.com/434827/89104100-11dc0b00-d45a-11ea-9e42-bc0f32011319.png)
