### PR TITLE
sfcli: initialize col variable

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -103,6 +103,7 @@ class SpiderFootCli(cmd.Cmd):
         cout = ""
         sout = ""
         pfx = ""
+        col = ""
         if err:
             pfx = "[!]"
             if self.ownopts['cli.color']:


### PR DESCRIPTION
Prevents this error:

```
# ./sfcli.py -k 
 
  _________      .__    .___          ___________            __  
 /   _____/_____ |__| __| _/__________\_   _____/___   _____/  |_ 
 \_____  \\____ \|  |/ __ |/ __ \_  __ \    __)/  _ \ /  _ \   __\
 /        \  |_> >  / /_/ \  ___/|  | \/     \(  <_> |  <_> )  |  
/_______  /   __/|__\____ |\___  >__|  \___  / \____/ \____/|__|  
        \/|__|           \/    \/          \/                     
                Open Source Intelligence Automation.
                by Steve Micallef | @spiderfoot

Traceback (most recent call last):
  File "./sfcli.py", line 1294, in <module>
    s.dprint("Version " + s.version + ".")
  File "./sfcli.py", line 127, in dprint
    cout = col + bcolors.BOLD + pfx + " " + bcolors.ENDC + \
UnboundLocalError: local variable 'col' referenced before assignment
```
