### PR TITLE
sfcli: Cast dict value as string

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -241,7 +241,7 @@ class SpiderFootCli(cmd.Cmd):
                 else:
                     # we have a dict key
                     cn = c
-                    v = r[c]
+                    v = str(r[c])
                 #print(str(cn) + ", " + str(c) + ", " + str(v))
                 if len(v) > maxsize.get(cn, 0):
                     maxsize[cn] = len(v)
@@ -303,7 +303,7 @@ class SpiderFootCli(cmd.Cmd):
                 else:
                     # we have a dict key
                     cn = c
-                    v = r[c]
+                    v = str(r[c])
                 if cn not in cols:
                     i += 1
                     continue


### PR DESCRIPTION
Prevent `TypeError: object of type 'int' has no len()`:

```
# ./sfcli.py 
 
  _________      .__    .___          ___________            __  
 /   _____/_____ |__| __| _/__________\_   _____/___   _____/  |_ 
 \_____  \\____ \|  |/ __ |/ __ \_  __ \    __)/  _ \ /  _ \   __\
 /        \  |_> >  / /_/ \  ___/|  | \/     \(  <_> |  <_> )  |  
/_______  /   __/|__\____ |\___  >__|  \___  / \____/ \____/|__|  
        \/|__|           \/    \/          \/                     
                Open Source Intelligence Automation.
                by Steve Micallef | @spiderfoot

[*] Version 3.2-DEV.
[*] Server http://127.0.0.1:5001 responding.
[*] Loaded previous command history.
[*] Type 'help' or '?'.
sf> query "SELECT '1'"
'1'  
---
1

[*] Total records: 1
sf> query "SELECT 1"
Traceback (most recent call last):
  File "./sfcli.py", line 1313, in <module>
    s.cmdloop()
  File "/usr/lib/python3.8/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python3.8/cmd.py", line 217, in onecmd
    return func(arg)
  File "./sfcli.py", line 530, in do_query
    self.send_output(d, line)
  File "./sfcli.py", line 445, in send_output
    out = self.pretty(j, titlemap=titles)
  File "./sfcli.py", line 246, in pretty
    if len(v) > maxsize.get(cn, 0):
TypeError: object of type 'int' has no len()
```
