### PR TITLE
sfweui: Use consistent formatting for data type column

### DIFF
--- a/dyn/scaninfo.tmpl
+++ b/dyn/scaninfo.tmpl
@@ -185,7 +185,7 @@
                                 for (var i = 0; i < data.length; i++) {
                                     table += "<tr>";
                                     if (typeName == null) {
-                                        table += "<td>" + data[i][8] + "</td>";
+                                        table += "<td><pre class='table-border-bg-inherit'>" + data[i][8] + "</pre></td>";
                                     }
                                     table += "<td><pre class='table-border-bg-inherit'>";
                                     table += sf.replace_sfurltag(data[i][1]);


### PR DESCRIPTION
Fix cell position alignment for `Data Element Type` column on scan info search results page to be consistent.

# Before

![image](https://user-images.githubusercontent.com/434827/90250202-11db0280-de7f-11ea-98f9-127e3e2e7a0e.png)

# After

![image](https://user-images.githubusercontent.com/434827/90250544-8ca41d80-de7f-11ea-8c1a-b2ad8e4afdb9.png)
