### PR TITLE
sflib: SpiderFootEvent: Use attributes and setters

### DIFF
--- a/sfdb.py
+++ b/sfdb.py
@@ -1162,13 +1162,12 @@ class SpiderFootDb:
                 storeData = storeData[0:truncateSize]
 
         # retrieve scan results
-        # sfEvent.getHash() will return the event hash for the input sfEvent event
         qry = "INSERT INTO tbl_scan_results \
             (scan_instance_id, hash, type, generated, confidence, \
             visibility, risk, module, data, source_event_hash) \
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
-        qvals = [instanceId, sfEvent.getHash(), sfEvent.eventType, sfEvent.generated,
+        qvals = [instanceId, sfEvent.hash, sfEvent.eventType, sfEvent.generated,
                  sfEvent.confidence, sfEvent.visibility, sfEvent.risk,
                  sfEvent.module, storeData, sfEvent.sourceEventHash]
 

--- a/test/unit/modules/test_sfp_bitcoin.py
+++ b/test/unit/modules/test_sfp_bitcoin.py
@@ -72,7 +72,7 @@ class TestModuleBitcoin(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_company.py
+++ b/test/unit/modules/test_sfp_company.py
@@ -72,7 +72,7 @@ class TestModuleCompany(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_countryname.py
+++ b/test/unit/modules/test_sfp_countryname.py
@@ -72,7 +72,7 @@ class TestModuleCountryName(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_creditcard.py
+++ b/test/unit/modules/test_sfp_creditcard.py
@@ -72,7 +72,7 @@ class TestModuleCreditCard(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_dnsresolve.py
+++ b/test/unit/modules/test_sfp_dnsresolve.py
@@ -72,7 +72,7 @@ class TestModuleDnsResolve(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_email.py
+++ b/test/unit/modules/test_sfp_email.py
@@ -72,7 +72,7 @@ class TestModuleEmail(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_errors.py
+++ b/test/unit/modules/test_sfp_errors.py
@@ -72,7 +72,7 @@ class TestModuleErrors(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_ethereum.py
+++ b/test/unit/modules/test_sfp_ethereum.py
@@ -72,7 +72,7 @@ class TestModuleEthereum(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_hashes.py
+++ b/test/unit/modules/test_sfp_hashes.py
@@ -72,7 +72,7 @@ class TestModuleHashes(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_hosting.py
+++ b/test/unit/modules/test_sfp_hosting.py
@@ -73,7 +73,7 @@ class TestModuleHosting(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_iban.py
+++ b/test/unit/modules/test_sfp_iban.py
@@ -72,7 +72,7 @@ class TestModuleIban(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_names.py
+++ b/test/unit/modules/test_sfp_names.py
@@ -72,7 +72,7 @@ class TestModuleNames(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_pageinfo.py
+++ b/test/unit/modules/test_sfp_pageinfo.py
@@ -72,7 +72,7 @@ class TestModulePageInfo(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_phone.py
+++ b/test/unit/modules/test_sfp_phone.py
@@ -72,7 +72,7 @@ class TestModulePhone(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_strangeheaders.py
+++ b/test/unit/modules/test_sfp_strangeheaders.py
@@ -72,7 +72,7 @@ class TestModuleStrangeHeaders(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_webanalytics.py
+++ b/test/unit/modules/test_sfp_webanalytics.py
@@ -72,7 +72,7 @@ class TestModuleWebAnalytics(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/modules/test_sfp_webframework.py
+++ b/test/unit/modules/test_sfp_webframework.py
@@ -72,7 +72,7 @@ class TestModuleWebFramework(unittest.TestCase):
         module.setTarget(target)
 
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example data'
         event_module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

--- a/test/unit/test_spiderfootdb.py
+++ b/test/unit/test_spiderfootdb.py
@@ -724,55 +724,6 @@ class TestSpiderFootDb(unittest.TestCase):
                 with self.assertRaises(TypeError) as cm:
                     sfdb.scanEventStore(instance_id, invalid_type)
 
-    def test_scanEventStore_argument_sfEvent_with_invalid_generated_property_type_should_raise_TypeError(self):
-        """
-        Test scanEventStore(self, instanceId, sfEvent, truncateSize=0)
-        """
-        sfdb = SpiderFootDb(self.default_options, False)
-
-        event_type = 'ROOT'
-        event_data = 'example data'
-        module = ''
-        source_event = ''
-        source_event = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        event_type = 'example event type'
-        event_data = 'example event data'
-        module = 'example module'
-        event = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        instance_id = "example instance id"
-        invalid_types = [None, "", list(), dict(), int()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    event = SpiderFootEvent(event_type, event_data, module, source_event)
-                    event.generated = invalid_type
-                    sfdb.scanEventStore(instance_id, event)
-
-    def test_scanEventStore_argument_sfEvent_with_empty_generated_property_value_should_raise_ValueError(self):
-        """
-        Test scanEventStore(self, instanceId, sfEvent, truncateSize=0)
-        """
-        sfdb = SpiderFootDb(self.default_options, False)
-
-        event_type = 'ROOT'
-        event_data = 'example data'
-        module = ''
-        source_event = ''
-        source_event = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        event_type = 'example event type'
-        event_data = 'example event data'
-        module = 'example module'
-        event = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        instance_id = "example instance id"
-        event.generated = float()
-
-        with self.assertRaises(ValueError) as cm:
-            sfdb.scanEventStore(instance_id, event)
-
     def test_scanEventStore_argument_sfEvent_with_invalid_eventType_property_type_should_raise_TypeError(self):
         """
         Test scanEventStore(self, instanceId, sfEvent, truncateSize=0)
@@ -817,9 +768,9 @@ class TestSpiderFootDb(unittest.TestCase):
         event = SpiderFootEvent(event_type, event_data, module, source_event)
 
         instance_id = "example instance id"
-        event.eventType = ''
 
         with self.assertRaises(ValueError) as cm:
+            event.eventType = ''
             sfdb.scanEventStore(instance_id, event)
 
     def test_scanEventStore_argument_sfEvent_with_invalid_data_property_type_should_raise_TypeError(self):
@@ -866,9 +817,9 @@ class TestSpiderFootDb(unittest.TestCase):
         event = SpiderFootEvent(event_type, event_data, module, source_event)
 
         instance_id = "example instance id"
-        event.data = ''
 
         with self.assertRaises(ValueError) as cm:
+            event.data = ''
             sfdb.scanEventStore(instance_id, event)
 
     def test_scanEventStore_argument_sfEvent_with_invalid_module_property_type_should_raise_TypeError(self):
@@ -915,8 +866,8 @@ class TestSpiderFootDb(unittest.TestCase):
         event = SpiderFootEvent(event_type, event_data, module, source_event)
 
         instance_id = "example instance id"
-        event.module = ''
         with self.assertRaises(ValueError) as cm:
+            event.module = ''
             sfdb.scanEventStore(instance_id, event)
 
     def test_scanEventStore_argument_sfEvent_with_invalid_confidence_property_type_should_raise_TypeError(self):
@@ -1100,54 +1051,6 @@ class TestSpiderFootDb(unittest.TestCase):
                     event = SpiderFootEvent(event_type, event_data, module, source_event)
                     event.sourceEvent = invalid_type
                     sfdb.scanEventStore(instance_id, event)
-
-    def test_scanEventStore_argument_sfEvent_with_invalid_sourceEventHash_property_type_should_raise_TypeError(self):
-        """
-        Test scanEventStore(self, instanceId, sfEvent, truncateSize=0)
-        """
-        sfdb = SpiderFootDb(self.default_options, False)
-
-        event_type = 'ROOT'
-        event_data = 'example data'
-        module = ''
-        source_event = ''
-        source_event = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        event_type = 'example event type'
-        event_data = 'example event data'
-        module = 'example module'
-        event = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        instance_id = "example instance id"
-        invalid_types = [None, list(), dict()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    event = SpiderFootEvent(event_type, event_data, module, source_event)
-                    event.sourceEventHash = invalid_type
-                    sfdb.scanEventStore(instance_id, event)
-
-    def test_scanEventStore_argument_sfEvent_with_empty_sourceEventHash_property_value_should_raise_ValueError(self):
-        """
-        Test scanEventStore(self, instanceId, sfEvent, truncateSize=0)
-        """
-        sfdb = SpiderFootDb(self.default_options, False)
-
-        event_type = 'ROOT'
-        event_data = 'example data'
-        module = ''
-        source_event = ''
-        source_event = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        event_type = 'example event type'
-        event_data = 'example event data'
-        module = 'example module'
-        event = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        instance_id = "example instance id"
-        event.sourceEventHash = ''
-        with self.assertRaises(ValueError) as cm:
-            sfdb.scanEventStore(instance_id, event)
 
     def test_scanInstanceList_should_return_a_list(self):
         """

--- a/test/unit/test_spiderfootevent.py
+++ b/test/unit/test_spiderfootevent.py
@@ -7,35 +7,66 @@ class TestSpiderFootEvent(unittest.TestCase):
     Test SpiderFootEvent
     """
 
-    def test_init_root_event(self):
+    def test_init_root_event_should_create_event(self):
         """
         Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
         """
-        event_data = ''
-        module = ''
+        event_data = 'example event data'
+        module = 'example module'
         source_event = ''
 
         event_type = 'ROOT'
         evt = SpiderFootEvent(event_type, event_data, module, source_event)
         self.assertIsInstance(evt, SpiderFootEvent)
 
-    def test_init_nonroot_event_with_root_source_event(self):
+    def test_init_nonroot_event_with_root_sourceEvent_should_create_event(self):
         """
         Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
         """
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example event data'
         module = ''
         source_event = ''
         source_event = SpiderFootEvent(event_type, event_data, module, source_event)
 
         event_type = 'example non-root event type'
-        event_data = ''
+        event_data = 'example event data'
         module = 'example module'
         evt = SpiderFootEvent(event_type, event_data, module, source_event)
         self.assertIsInstance(evt, SpiderFootEvent)
 
-    def test_init_invalid_event_data_type_should_raise(self):
+    def test_init_argument_eventType_of_invalid_type_should_raise_TypeError(self):
+        """
+        Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
+        """
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        source_event = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        module = 'example module'
+ 
+        invalid_types = [None, list(), dict()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    evt = SpiderFootEvent(invalid_type, event_data, module, source_event)
+
+    def test_init_argument_eventType_with_empty_value_should_raise_ValueError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        source_event = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        event_type = ''
+        module = 'example module'
+
+        with self.assertRaises(ValueError) as cm:
+            evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+    def test_init_argument_data_of_invalid_type_should_raise_TypeError(self):
         """
         Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
         """
@@ -49,26 +80,220 @@ class TestSpiderFootEvent(unittest.TestCase):
                 with self.assertRaises(TypeError) as cm:
                     evt = SpiderFootEvent(event_type, invalid_type, module, source_event)
 
-    def test_init_invalid_source_event_type_should_raise(self):
+    def test_init_argument_data_with_empty_value_should_raise_ValueError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        source_event = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        event_type = 'example event type'
+        event_data = ''
+        module = 'example module'
+
+        with self.assertRaises(ValueError) as cm:
+            evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+    def test_init_argument_module_of_invalid_type_should_raise_TypeError(self):
         """
         Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
         """
+        event_type = 'ROOT'
         event_data = 'example event data'
-        module = 'example module'
-        event_type = 'example non-root event type'
+        module = ''
+        source_event = SpiderFootEvent(event_type, event_data, module, "ROOT")
 
+        event_type = 'example non-root event type'
+        invalid_types = [None, list(), dict()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    evt = SpiderFootEvent(event_type, event_data, invalid_type, source_event)
+
+    def test_init_argument_module_with_empty_value_should_raise_ValueError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        source_event = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        event_type = 'example event type'
+        event_data = 'example event data'
+        module = ''
+
+        with self.assertRaises(ValueError) as cm:
+            evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+    def test_init_argument_sourceEvent_of_invalid_type_should_raise_TypeError(self):
+        """
+        Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
+        """
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = SpiderFootEvent(event_type, event_data, module, "ROOT")
+
+        event_type = 'example non-root event type'
+        module = 'example module'
         invalid_types = [None, "", list(), dict()]
         for invalid_type in invalid_types:
             with self.subTest(invalid_type=invalid_type):
                 with self.assertRaises(TypeError) as cm:
                     evt = SpiderFootEvent(event_type, event_data, module, invalid_type)
 
-    def test_asdict_root_event_should_return_a_dict(self):
+    def test_init_argument_confidence_of_invalid_type_should_raise_TypeError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_types = [None, "", list(), dict()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event, confidence=invalid_type)
+
+    def test_init_argument_confidence_invalid_value_should_raise_ValueError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_values = [-1, 101]
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=invalid_value):
+                with self.assertRaises(ValueError) as cm:
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event, confidence=invalid_value)
+
+    def test_init_argument_visibility_of_invalid_type_should_raise_TypeError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_types = [None, "", list(), dict()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event, visibility=invalid_type)
+
+    def test_init_argument_visibility_invalid_value_should_raise_ValueError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_values = [-1, 101]
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=invalid_value):
+                with self.assertRaises(ValueError) as cm:
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event, visibility=invalid_value)
+
+    def test_init_argument_risk_of_invalid_type_should_raise_TypeError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_types = [None, "", list(), dict()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event, risk=invalid_type)
+
+    def test_init_argument_risk_invalid_value_should_raise_ValueError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_values = [-1, 101]
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=invalid_value):
+                with self.assertRaises(ValueError) as cm:
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event, risk=invalid_value)
+
+    def test_confidence_attribute_should_return_confidence_as_integer(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        confidence = 100
+        evt = SpiderFootEvent(event_type, event_data, module, source_event, confidence=confidence)
+
+        self.assertEqual(confidence, evt.confidence)
+
+    def test_confidence_attribute_setter_invalid_type_should_raise_TypeError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_types = [None, "", list(), dict()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    evt.confidence = invalid_type
+
+    def test_visibility_attribute_should_return_visibility_as_integer(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        visibility = 100
+        evt = SpiderFootEvent(event_type, event_data, module, source_event, visibility=visibility)
+
+        self.assertEqual(visibility, evt.visibility)
+
+    def test_visibility_attribute_setter_invalid_type_should_raise_TypeError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_types = [None, "", list(), dict()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    evt.visibility = invalid_type
+
+    def test_risk_attribute_should_return_risk_as_integer(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        risk = 100
+        evt = SpiderFootEvent(event_type, event_data, module, source_event, risk=risk)
+
+        self.assertEqual(risk, evt.risk)
+
+    def test_risk_attribute_setter_invalid_type_should_raise_TypeError(self):
+        event_type = 'ROOT'
+        event_data = 'example event data'
+        module = ''
+        source_event = ''
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+
+        invalid_types = [None, "", list(), dict()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    evt.risk = invalid_type
+
+    def test_asdict_root_event_should_return_event_as_a_dict(self):
         """
         Test asDict(self)
         """
-        event_data = ''
-        module = ''
+        event_data = 'example event data'
+        module = 'example module data'
         source_event = ''
 
         event_type = 'ROOT'
@@ -76,31 +301,37 @@ class TestSpiderFootEvent(unittest.TestCase):
         evt_dict = evt.asDict()
 
         self.assertIsInstance(evt_dict, dict)
+        self.assertEqual(evt_dict['type'], event_type)
+        self.assertEqual(evt_dict['data'], event_data)
+        self.assertEqual(evt_dict['module'], module)
 
-    def test_asdict_nonroot_event_should_return_a_dict(self):
+    def test_asdict_nonroot_event_should_return_event_as_a_dict(self):
         """
         Test asDict(self)
         """
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example event data'
         module = ''
         source_event = ''
         source_event = SpiderFootEvent(event_type, event_data, module, source_event)
 
         event_type = 'example non-root event type'
-        event_data = ''
+        event_data = 'example event data'
         module = 'example_module'
         evt = SpiderFootEvent(event_type, event_data, module, source_event)
         evt_dict = evt.asDict()
 
         self.assertIsInstance(evt_dict, dict)
+        self.assertEqual(evt_dict['type'], event_type)
+        self.assertEqual(evt_dict['data'], event_data)
+        self.assertEqual(evt_dict['module'], module)
 
-    def test_get_hash_root_event_should_return_root_as_a_string(self):
+    def test_getHash_root_event_should_return_root_as_a_string(self):
         """
         Test getHash(self)
         """
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example event data'
         module = ''
         source_event = ''
 
@@ -109,138 +340,20 @@ class TestSpiderFootEvent(unittest.TestCase):
 
         self.assertEqual('ROOT', evt_hash)
 
-    def test_get_hash_nonroot_event_should_return_a_string(self):
+    def test_getHash_nonroot_event_should_return_a_string(self):
         """
         Test getHash(self)
         """
-        event_type = 'not ROOT'
-        event_data = ''
+        event_type = 'ROOT'
+        event_data = 'example event data'
         module = 'example module'
-        source_event = SpiderFootEvent("ROOT", '', '', "ROOT")
+        source_event = SpiderFootEvent(event_type, event_data, module, "ROOT")
 
+        event_type = 'not ROOT'
         evt = SpiderFootEvent(event_type, event_data, module, source_event)
         evt_hash = evt.getHash()
 
         self.assertIsInstance(evt_hash, str)
-
-    def test_set_confidence_invalid_confidence_should_raise(self):
-        """
-        Test setConfidence(self, confidence)
-        """
-        event_type = 'ROOT'
-        event_data = ''
-        module = ''
-        source_event = ''
-        evt = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        invalid_types = [None, "", list(), dict()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    evt.setConfidence(invalid_type)
-
-        with self.assertRaises(ValueError) as cm:
-            evt.setConfidence(-1)
-        with self.assertRaises(ValueError) as cm:
-            evt.setConfidence(101)
-
-    def test_set_confidence_should_set_confidence_attribute(self):
-        """
-        Test setConfidence(self, confidence)
-        """
-        event_type = 'ROOT'
-        event_data = ''
-        module = ''
-        source_event = ''
-        evt = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        confidence = 100
-        evt.setConfidence(confidence)
-        self.assertEqual(confidence, evt.confidence)
-
-    def test_set_visibility_invalid_visibility_should_raise(self):
-        """
-        Test setVisibility(self, visibility)
-        """
-        event_type = 'ROOT'
-        event_data = ''
-        module = ''
-        source_event = ''
-        evt = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        invalid_types = [None, "", list(), dict()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    evt.setVisibility(invalid_type)
-
-        with self.assertRaises(ValueError) as cm:
-            evt.setVisibility(-1)
-        with self.assertRaises(ValueError) as cm:
-            evt.setVisibility(101)
-
-    def test_set_visibility_should_set_visibility_attribute(self):
-        """
-        Test setVisibility(self, visibility)
-        """
-        event_type = 'ROOT'
-        event_data = ''
-        module = ''
-        source_event = ''
-        evt = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        visibility = 100
-        evt.setVisibility(visibility)
-        self.assertEqual(visibility, evt.visibility)
-
-    def test_set_risk_invalid_risk_should_raise(self):
-        """
-        Test setRisk(self, risk)
-        """
-        event_type = 'ROOT'
-        event_data = ''
-        module = ''
-        source_event = ''
-        evt = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        invalid_types = [None, "", list(), dict()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    evt.setRisk(invalid_type)
-
-        with self.assertRaises(ValueError) as cm:
-            evt.setRisk(-1)
-        with self.assertRaises(ValueError) as cm:
-            evt.setRisk(101)
-
-    def test_set_risk_should_set_risk_attribute(self):
-        """
-        Test setRisk(self, risk)
-        """
-        event_type = 'ROOT'
-        event_data = ''
-        module = ''
-        source_event = ''
-        evt = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        risk = 100
-        evt.setRisk(risk)
-        self.assertEqual(risk, evt.risk)
-
-    def test_set_source_event_hash_should_set_source_event_hash_attribute(self):
-        """
-        Test setSourceEventHash(self, srcHash)
-        """
-        event_type = 'ROOT'
-        event_data = ''
-        module = ''
-        source_event = ''
-        evt = SpiderFootEvent(event_type, event_data, module, source_event)
-
-        source_event_hash = 'source event hash'
-        evt.setSourceEventHash(source_event_hash)
-        self.assertEqual(source_event_hash, evt.sourceEventHash)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_spiderfootplugin.py
+++ b/test/unit/test_spiderfootplugin.py
@@ -281,7 +281,7 @@ class TestSpiderFootPlugin(unittest.TestCase):
         Test handleEvent(self, sfEvent)
         """
         event_type = 'ROOT'
-        event_data = ''
+        event_data = 'example event data'
         module = ''
         source_event = ''
         evt = SpiderFootEvent(event_type, event_data, module, source_event)


### PR DESCRIPTION
This PR rewrites much of the `SpiderFootEvent` class to use `@property` and `@property.setter`.

All the validation logic has been moved out of the `init` function into the getters/setters. There are no setters for properties which should be private (ie, `self.generated`).

The `setConfidence` / `setVisibility` / `setRisk` functions have been removed. Appropriate getters and setters now exist for these properties.

The `sourceEventHash` property is now calculated automatically when the `sourceEvent` is set. It can no longer be set outside of the class, as there should never be a reason for the source event hash to be set manually. Changing the hash requires changing the `sourceEvent`.

The `getHash` function has been replaced with a `hash` property and can no longer be set outside the class, as there should never be a reason for the hash to be set manually. The `getHash` function remains for compatibility with SpiderFoot HX; however, is now a simple wrapper around the `self.hash` property.

The unit tests were updated to accommodate these changes.
