### PR TITLE
sfscan: set all attributes and functions to private

### DIFF
--- a/sfscan.py
+++ b/sfscan.py
@@ -17,226 +17,272 @@ import dns.resolver
 import random
 from copy import deepcopy
 from sfdb import SpiderFootDb
-from sflib import SpiderFoot, SpiderFootEvent, SpiderFootTarget, \
-    SpiderFootPlugin
+from sflib import SpiderFoot, SpiderFootEvent, SpiderFootTarget, SpiderFootPlugin
 
 class SpiderFootScanner():
-    def __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True):
+    """SpiderFootScanner object.
+
+    Attributes:
+        scanId (str): unique ID of the scan
+        status (str): status of the scan
+    """
+
+    __scanId = None
+    __status = None
+    __config = None
+    __sf = None
+    __dbh = None
+    __targetValue = None
+    __targetType = None
+    __moduleList = list()
+    __target = None
+    __moduleInstances = dict()
+    __modconfig = dict()
+    __scanName = None
+
+    def __init__(self, scanName, scanId, targetValue, targetType, moduleList, globalOpts, start=True):
         """Initialize SpiderFootScanner object.
 
         Args:
             scanName (str): name of the scan
             scanId (str): unique ID of the scan
-            scanTarget (str): scan target
+            targetValue (str): scan target
             targetType (str): scan target type
             moduleList (list): list of modules to run
             globalOpts (dict): scan options
             start (bool): start the scan immediately
 
-        Returns:
-            None
+        Raises:
+            TypeError: arg type was invalid
+            ValueError: arg value was invalid
 
         Todo:
              Eventually change this to be able to control multiple scan instances
         """
+        print(str(moduleList))
 
-        if not isinstance(scanName, str):
-            raise TypeError("scanName is %s; expected str()" % type(scanName))
-        if not isinstance(scanId, str):
-            raise TypeError("scanId is %s; expected str()" % type(scanId))
-        if not isinstance(scanTarget, str):
-            raise TypeError("scanTarget is %s; expected str()" % type(scanTarget))
-        if not isinstance(targetType, str):
-            raise TypeError("targetType is %s; expected str()" % type(targetType))
-        if not isinstance(moduleList, list):
-            raise TypeError("moduleList is %s; expected list()" % type(moduleList))
         if not isinstance(globalOpts, dict):
-            raise TypeError("globalOpts is %s; expected dict()" % type(globalOpts))
+            raise TypeError(f"globalOpts is {type(globalOpts)}; expected dict()")
         if not globalOpts:
             raise ValueError("globalOpts is empty")
 
-        self.moduleInstances = dict()
-        self.config = deepcopy(globalOpts)
-        self.sf = SpiderFoot(self.config)
-        self.dbh = SpiderFootDb(self.config)
-        self.targetValue = scanTarget
-        self.targetType = targetType
-        self.moduleList = moduleList
-        self.modconfig = dict()
-        self.scanName = scanName
-        self.sf.setDbh(self.dbh)
+        self.__config = deepcopy(globalOpts)
+        self.__dbh = SpiderFootDb(self.__config)
 
-        # Create a unique ID for this scan and create it in the back-end DB.
-        self.scanId = scanId
-        self.sf.setGUID(self.scanId)
-        self.dbh.scanInstanceCreate(self.scanId, self.scanName, self.targetValue)
+        if not isinstance(scanName, str):
+            raise TypeError(f"scanName is {type(scanName)}; expected str()")
+        if not scanName:
+            raise ValueError("scanName value is blank")
+
+        self.__scanName = scanName
+
+        if not isinstance(scanId, str):
+            raise TypeError(f"scanId is {type(scanId)}; expected str()")
+        if not scanId:
+            raise ValueError("scanId value is blank")
+
+        if not isinstance(targetValue, str):
+            raise TypeError(f"targetValue is {type(targetValue)}; expected str()")
+        if not targetValue:
+            raise ValueError("targetValue value is blank")
+
+        self.__targetValue = targetValue
+
+        if not isinstance(targetType, str):
+            raise TypeError(f"targetType is {type(targetType)}; expected str()")
+        if not targetType:
+            raise ValueError("targetType value is blank")
+
+        self.__targetType = targetType
+
+        if not isinstance(moduleList, list):
+            raise TypeError(f"moduleList is {type(moduleList)}; expected list()")
+        if not moduleList:
+            raise ValueError("moduleList is empty")
+
+        self.__moduleList = moduleList
+
+        self.__sf = SpiderFoot(self.__config)
+        self.__sf.setDbh(self.__dbh)
+
+        # Create a unique ID for this scan in the back-end DB.
+        if not isinstance(scanId, str):
+            raise TypeError(f"scanId is {type(scanId)}; expected str()")
+
+        if scanId:
+            self.__scanId = scanId
+        else:
+            self.__scanId = self.__sf.genScanInstanceGUID()
+
+        self.__sf.setGUID(self.__scanId)
+        self.__dbh.scanInstanceCreate(self.__scanId, self.__scanName, self.__targetValue)
 
         # Create our target
         try:
-            self.target = SpiderFootTarget(self.targetValue, self.targetType)
-        except ValueError as e:
-            self.sf.status("Scan [%s] failed: %s" % (self.scanId, e))
-            self.setStatus("ERROR-FAILED", None, time.time() * 1000)
-            raise ValueError("Invalid target: %s" % e)
-        except TypeError as e:
-            self.sf.status("Scan [%s] failed: %s" % (self.scanId, e))
-            self.setStatus("ERROR-FAILED", None, time.time() * 1000)
-            raise TypeError("Invalid target: %s" % e)
+            self.__target = SpiderFootTarget(self.__targetValue, self.__targetType)
+        except (TypeError, ValueError) as e:
+            self.__sf.status(f"Scan [{self.__scanId}] failed: {e}")
+            self.__setStatus("ERROR-FAILED", None, time.time() * 1000)
+            raise ValueError(f"Invalid target: {e}")
 
         # Save the config current set for this scan
-        self.config['_modulesenabled'] = self.moduleList
-        self.dbh.scanConfigSet(self.scanId, self.sf.configSerialize(deepcopy(self.config)))
+        self.__config['_modulesenabled'] = self.__moduleList
+        self.__dbh.scanConfigSet(self.__scanId, self.__sf.configSerialize(deepcopy(self.__config)))
 
         # Process global options that point to other places for data
 
         # If a SOCKS server was specified, set it up
-        if self.config['_socks1type']:
-            socksDns = self.config['_socks6dns']
-            socksAddr = self.config['_socks2addr']
-            socksPort = int(self.config['_socks3port'])
-            socksUsername = self.config['_socks4user'] or ''
-            socksPassword = self.config['_socks5pwd'] or ''
+        if self.__config['_socks1type']:
+            socksDns = self.__config['_socks6dns']
+            socksAddr = self.__config['_socks2addr']
+            socksPort = int(self.__config['_socks3port'])
+            socksUsername = self.__config['_socks4user'] or ''
+            socksPassword = self.__config['_socks5pwd'] or ''
 
-            proxy = "%s:%s" % (socksAddr, socksPort)
+            proxy = f"{socksAddr}:{socksPort}"
 
             if socksUsername or socksPassword:
                 proxy = "%s:%s@%s" % (socksUsername, socksPassword, proxy)
 
-            if self.config['_socks1type'] == '4':
+            if self.__config['_socks1type'] == '4':
                 proxy = 'socks4://' + proxy
-            elif self.config['_socks1type'] == '5':
+            elif self.__config['_socks1type'] == '5':
                 proxy = 'socks5://' + proxy
-            elif self.config['_socks1type'] == 'HTTP':
+            elif self.__config['_socks1type'] == 'HTTP':
                 proxy = 'http://' + proxy
-            elif self.config['_socks1type'] == 'TOR':
+            elif self.__config['_socks1type'] == 'TOR':
                 proxy = 'socks5h://' + proxy
             else:
-                raise ValueError("Invalid SOCKS proxy type: %s" % self.config["_socks1ttype"])
+                raise ValueError(f"Invalid SOCKS proxy type: {self.__config['_socks1ttype']}")
 
-            self.sf.debug("SOCKS: %s:%s (%s:%s)" % (socksAddr, socksPort, socksUsername, socksPassword))
+            self.__sf.debug(f"SOCKS: {socksAddr}:{socksPort} ({socksUsername}:{socksPassword})")
 
-            self.sf.updateSocket(proxy)
+            self.__sf.updateSocket(proxy)
         else:
-            self.sf.revertSocket()
+            self.__sf.revertSocket()
 
         # Override the default DNS server
-        if self.config['_dnsserver']:
+        if self.__config['_dnsserver']:
             res = dns.resolver.Resolver()
-            res.nameservers = [self.config['_dnsserver']]
+            res.nameservers = [self.__config['_dnsserver']]
             dns.resolver.override_system_resolver(res)
         else:
             dns.resolver.restore_system_resolver()
 
         # Set the user agent
-        self.config['_useragent'] = self.sf.optValueToData(self.config['_useragent'])
+        self.__config['_useragent'] = self.__sf.optValueToData(self.__config['_useragent'])
 
         # Get internet TLDs
-        tlddata = self.sf.cacheGet("internet_tlds", self.config['_internettlds_cache'])
+        tlddata = self.__sf.cacheGet("internet_tlds", self.__config['_internettlds_cache'])
 
         # If it wasn't loadable from cache, load it from scratch
         if tlddata is None:
-            self.config['_internettlds'] = self.sf.optValueToData(self.config['_internettlds'])
-            self.sf.cachePut("internet_tlds", self.config['_internettlds'])
+            self.__config['_internettlds'] = self.__sf.optValueToData(self.__config['_internettlds'])
+            self.__sf.cachePut("internet_tlds", self.__config['_internettlds'])
         else:
-            self.config["_internettlds"] = tlddata.splitlines()
+            self.__config["_internettlds"] = tlddata.splitlines()
 
-        self.setStatus("INITIALIZING", time.time() * 1000, None)
+        self.__setStatus("INITIALIZING", time.time() * 1000, None)
 
         if start:
-            self.startScan()
+            self.__startScan()
 
-    def getId(self):
-        """Retrieve the unique scan identifier.
+    @property
+    def scanId(self):
+        """Unique identifier for this scan"""
+        return self.__scanId
 
-        Returns:
-            str: scan id
-        """
-        if hasattr(self, 'scanId'):
-            return self.scanId
-        return None
+    @property
+    def status(self):
+        """Status of this scan"""
+        return self.__status
 
-    def setStatus(self, status, started=None, ended=None):
+    def __setStatus(self, status, started=None, ended=None):
         """Set the status of the currently running scan (if any).
 
         Args:
             status (str): scan status
-            started (str): TBD
-            ended (str): TBD
+            started (float): timestamp at start of scan
+            ended (float): timestamp at end of scan
 
         Returns:
             None
+
+        Raises:
+            TypeError: arg type was invalid
+            ValueError: arg value was invalid
         """
+        if not isinstance(status, str):
+            raise TypeError(f"status is {type(status)}; expected str()")
 
         if status not in ["INITIALIZING", "STARTING", "STARTED", "RUNNING", "ABORT-REQUESTED", "ABORTED", "ABORTING", "FINISHED", "ERROR-FAILED"]:
-            raise ValueError("Invalid scan status '%s'" % status)
+            raise ValueError(f"Invalid scan status {status}")
 
-        self.status = status
-        self.dbh.scanInstanceSet(self.scanId, started, ended, status)
-        return None
+        self.__status = status
+        self.__dbh.scanInstanceSet(self.__scanId, started, ended, status)
 
-    def startScan(self):
+    def __startScan(self):
         """Start running a scan."""
 
         aborted = False
 
-        self.setStatus("STARTING", time.time() * 1000, None)
-        self.sf.status("Scan [" + self.scanId + "] initiated.")
+        self.__setStatus("STARTING", time.time() * 1000, None)
+        self.__sf.status(f"Scan [{self.__scanId}] initiated.")
 
         try:
             # moduleList = list of modules the user wants to run
-            for modName in self.moduleList:
+            for modName in self.__moduleList:
                 if modName == '':
                     continue
 
                 try:
-                    module = __import__('modules.' + modName, globals(), locals(),
-                                        [modName])
+                    module = __import__('modules.' + modName, globals(), locals(), [modName])
                 except ImportError:
-                    self.sf.error("Failed to load module: " + modName, False)
+                    self.__sf.error("Failed to load module: " + modName, False)
                     continue
 
                 mod = getattr(module, modName)()
                 mod.__name__ = modName
 
                 # Module may have been renamed or removed
-                if modName not in self.config['__modules__']:
+                if modName not in self.__config['__modules__']:
                     continue
 
                 # Set up the module
                 # Configuration is a combined global config with module-specific options
-                self.modconfig[modName] = deepcopy(self.config['__modules__'][modName]['opts'])
-                for opt in list(self.config.keys()):
-                    self.modconfig[modName][opt] = deepcopy(self.config[opt])
+                self.__modconfig[modName] = deepcopy(self.__config['__modules__'][modName]['opts'])
+                for opt in list(self.__config.keys()):
+                    self.__modconfig[modName][opt] = deepcopy(self.__config[opt])
 
                 mod.clearListeners()  # clear any listener relationships from the past
-                mod.setup(self.sf, self.modconfig[modName])
-                mod.setDbh(self.dbh)
-                mod.setScanId(self.scanId)
+                mod.setup(self.__sf, self.__modconfig[modName])
+                mod.setDbh(self.__dbh)
+                mod.setScanId(self.__scanId)
 
                 # Give modules a chance to 'enrich' the original target with
                 # aliases of that target.
-                newTarget = mod.enrichTarget(self.target)
+                newTarget = mod.enrichTarget(self.__target)
                 if newTarget is not None:
-                    self.target = newTarget
-                self.moduleInstances[modName] = mod
+                    self.__target = newTarget
+                self.__moduleInstances[modName] = mod
 
                 # Override the module's local socket module
                 # to be the SOCKS one.
-                if self.config['_socks1type'] != '':
+                if self.__config['_socks1type'] != '':
                     mod._updateSocket(socket)
 
                 # Set up event output filters if requested
-                if self.config['__outputfilter']:
-                    mod.setOutputFilter(self.config['__outputfilter'])
+                if self.__config['__outputfilter']:
+                    mod.setOutputFilter(self.__config['__outputfilter'])
 
-                self.sf.status(modName + " module loaded.")
+                self.__sf.status(modName + " module loaded.")
 
             # Register listener modules and then start all modules sequentially
-            for module in list(self.moduleInstances.values()):
+            for module in list(self.__moduleInstances.values()):
                 # Register the target with the module
-                module.setTarget(self.target)
+                module.setTarget(self.__target)
 
-                for listenerModule in list(self.moduleInstances.values()):
+                for listenerModule in list(self.__moduleInstances.values()):
                     # Careful not to register twice or you will get duplicate events
                     if listenerModule in module._listenerModules:
                         continue
@@ -247,29 +293,29 @@ class SpiderFootScanner():
                         module.registerListener(listenerModule)
 
             # Now we are ready to roll..
-            self.setStatus("RUNNING")
+            self.__setStatus("RUNNING")
 
             # Create a pseudo module for the root event to originate from
             psMod = SpiderFootPlugin()
             psMod.__name__ = "SpiderFoot UI"
-            psMod.setTarget(self.target)
-            psMod.setDbh(self.dbh)
+            psMod.setTarget(self.__target)
+            psMod.setDbh(self.__dbh)
             psMod.clearListeners()
-            for mod in list(self.moduleInstances.values()):
+            for mod in list(self.__moduleInstances.values()):
                 if mod.watchedEvents() is not None:
                     psMod.registerListener(mod)
 
             # Create the "ROOT" event which un-triggered modules will link events to
-            rootEvent = SpiderFootEvent("ROOT", self.targetValue, "", None)
+            rootEvent = SpiderFootEvent("ROOT", self.__targetValue, "", None)
             psMod.notifyListeners(rootEvent)
-            firstEvent = SpiderFootEvent(self.targetType, self.targetValue,
+            firstEvent = SpiderFootEvent(self.__targetType, self.__targetValue,
                                          "SpiderFoot UI", rootEvent)
             psMod.notifyListeners(firstEvent)
 
             # Special case.. check if an INTERNET_NAME is also a domain
-            if self.targetType == 'INTERNET_NAME':
-                if self.sf.isDomain(self.targetValue, self.config['_internettlds']):
-                    firstEvent = SpiderFootEvent('DOMAIN_NAME', self.targetValue,
+            if self.__targetType == 'INTERNET_NAME':
+                if self.__sf.isDomain(self.__targetValue, self.__config['_internettlds']):
+                    firstEvent = SpiderFootEvent('DOMAIN_NAME', self.__targetValue,
                                                  "SpiderFoot UI", rootEvent)
                     psMod.notifyListeners(firstEvent)
 
@@ -279,24 +325,24 @@ class SpiderFootScanner():
 
             # Check in case the user requested to stop the scan between modules
             # initializing
-            for module in list(self.moduleInstances.values()):
+            for module in list(self.__moduleInstances.values()):
                 if module.checkForStop():
-                    self.setStatus('ABORTING')
+                    self.__setStatus('ABORTING')
                     aborted = True
                     break
 
             if aborted:
-                self.sf.status("Scan [" + self.scanId + "] aborted.")
-                self.setStatus("ABORTED", None, time.time() * 1000)
+                self.__sf.status("Scan [" + self.__scanId + "] aborted.")
+                self.__setStatus("ABORTED", None, time.time() * 1000)
             else:
-                self.sf.status("Scan [" + self.scanId + "] completed.")
-                self.setStatus("FINISHED", None, time.time() * 1000)
+                self.__sf.status("Scan [" + self.__scanId + "] completed.")
+                self.__setStatus("FINISHED", None, time.time() * 1000)
         except BaseException as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()
-            self.sf.error("Unhandled exception (" + e.__class__.__name__ + ") " + \
+            self.__sf.error("Unhandled exception (" + e.__class__.__name__ + ") " + \
                              "encountered during scan. Please report this as a bug: " + \
                              repr(traceback.format_exception(exc_type, exc_value, exc_traceback)), False)
-            self.sf.status("Scan [" + self.scanId + "] failed: " + str(e))
-            self.setStatus("ERROR-FAILED", None, time.time() * 1000)
+            self.__sf.status("Scan [" + self.__scanId + "] failed: " + str(e))
+            self.__setStatus("ERROR-FAILED", None, time.time() * 1000)
 
-        self.dbh.close()
+        self.__dbh.close()

--- a/test/unit/test_spiderfootscanner.py
+++ b/test/unit/test_spiderfootscanner.py
@@ -35,129 +35,191 @@ class TestSpiderFootScanner(unittest.TestCase):
       '__logstdout': False
     }
 
-    def test_init(self):
+    def test_init_argument_start_false_should_create_a_scan_without_starting_the_scan(self):
         """
         Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
         """
         opts = self.default_options
         opts['__modules__'] = dict()
         scan_id = str(uuid.uuid4())
-        sfscan = SpiderFootScanner("", scan_id, "spiderfoot.net", "IP_ADDRESS", list(), opts, start=False)
+        module_list = ['sfp__stor_db']
+
+        sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, opts, start=False)
         self.assertIsInstance(sfscan, SpiderFootScanner)
+        self.assertEqual(sfscan.status, "INITIALIZING")
 
-    def test_init_invalid_scan_name_should_raise(self):
-        """
-        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
-        """
-        scan_id = str(uuid.uuid4())
-        with self.assertRaises(TypeError) as cm:
-            sfscan = SpiderFootScanner(None, scan_id, "", "IP_ADDRESS", list(), self.default_options, start=False)
-
-    def test_init_invalid_scan_id_should_raise(self):
-        """
-        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
-        """
-        scan_id = None
-        with self.assertRaises(TypeError) as cm:
-            sfscan = SpiderFootScanner("", scan_id, "", "IP_ADDRESS", list(), self.default_options, start=False)
-
-    def test_init_invalid_targetvalue_type_should_raise(self):
-        """
-        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
-        """
-        scan_id = str(uuid.uuid4())
-        invalid_types = [None, list(), dict()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    sfscan = SpiderFootScanner("", scan_id, invalid_type, "IP_ADDRESS", list(), self.default_options, start=False)
-
-    def test_init_blank_targetvalue_value_should_raise(self):
-        """
-        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
-        """
-        scan_id = str(uuid.uuid4())
-        with self.assertRaises(TypeError) as cm:
-            sfscan = SpiderFootScanner("", scan_id, None, "IP_ADDRESS", list(), self.default_options, start=False)
-
-    def test_init_invalid_targettype_type_should_raise(self):
-        """
-        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
-        """
-        scan_id = str(uuid.uuid4())
-        invalid_types = [None, list(), dict()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    sfscan = SpiderFootScanner("", scan_id, "spiderfoot.net", invalid_type, list(), self.default_options, start=False)
-
-    def test_init_blank_targettype_value_should_raise(self):
-        """
-        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
-        """
-        scan_id = str(uuid.uuid4())
-        with self.assertRaises(ValueError) as cm:
-            sfscan = SpiderFootScanner("", scan_id, "spiderfoot.net", "invalid target type", list(), self.default_options, start=False)
-
-    def test_init_invalid_module_list_should_raise(self):
-        """
-        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
-        """
-        scan_id = str(uuid.uuid4())
-        invalid_types = [None, "", dict()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    sfscan = SpiderFootScanner("", scan_id, "spiderfoot.net", "IP_ADDRESS", invalid_type, self.default_options, start=False)
-
-    def test_init_invalid_options_should_raise(self):
-        """
-        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
-        """
-        scan_id = str(uuid.uuid4())
-        invalid_types = [None, "", list()]
-        for invalid_type in invalid_types:
-            with self.subTest(invalid_type=invalid_type):
-                with self.assertRaises(TypeError) as cm:
-                    sfscan = SpiderFootScanner("", scan_id, "spiderfoot.net", "IP_ADDRESS", list(), invalid_type, start=False)
-
-        scan_id = str(uuid.uuid4())
-        with self.assertRaises(ValueError) as cm:
-            sfscan = SpiderFootScanner("", scan_id, "", "IP_ADDRESS", list(), dict(), start=False)
-
-    def test_set_status_invalid_status_should_raise(self):
-        """
-        Test def setStatus(self, status, started=None, ended=None)
-        """
+    def test_init_argument_start_true_should_create_and_start_a_scan(self):
         opts = self.default_options
         opts['__modules__'] = dict()
         scan_id = str(uuid.uuid4())
-        sfscan = SpiderFootScanner("", scan_id, "spiderfoot.net", "IP_ADDRESS", list(), opts, start=False)
+        module_list = ['sfp__stor_db']
+
+        sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, opts, start=True)
         self.assertIsInstance(sfscan, SpiderFootScanner)
+        self.assertEqual(sfscan.status, "FINISHED")
+
+    def test_init_argument_scanName_of_invalid_type_should_raise_TypeError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        invalid_types = [None, list(), dict(), int()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    sfscan = SpiderFootScanner(invalid_type, scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, self.default_options, start=False)
+
+    def test_init_argument_scanName_as_empty_string_should_raise_ValueError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
 
         with self.assertRaises(ValueError) as cm:
-            sfscan.setStatus("invalid status", None, None)
+            sfscan = SpiderFootScanner("", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, self.default_options, start=False)
 
-    def test_get_id_should_return_a_scan_id(self):
+    def test_init_argument_scanId_of_invalid_type_should_raise_TypeError(self):
         """
-        Test def getId(self)
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
         """
+        module_list = ['sfp__stor_db']
+
+        invalid_types = [None, list(), dict(), int()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    sfscan = SpiderFootScanner("example scan name", invalid_type, "spiderfoot.net", "IP_ADDRESS", module_list, self.default_options, start=False)
+
+    def test_init_argument_scanId_as_empty_string_should_raise_ValueError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
+        """
+        scan_id = ""
+        module_list = ['sfp__stor_db']
+
+        with self.assertRaises(ValueError) as cm:
+            sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, self.default_options, start=False)
+
+    def test_init_argument_targetValue_of_invalid_type_should_raise_TypeError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        invalid_types = [None, list(), dict(), int()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    sfscan = SpiderFootScanner("example scan name", scan_id, invalid_type, "IP_ADDRESS", module_list, self.default_options, start=False)
+
+    def test_init_argument_targetValue_as_empty_string_should_raise_ValueError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts, start=True)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        with self.assertRaises(ValueError) as cm:
+            sfscan = SpiderFootScanner("example scan name", scan_id, "", "IP_ADDRESS", module_list, self.default_options, start=False)
+
+    def test_init_argument_targetType_of_invalid_type_should_raise_TypeError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        invalid_types = [None, list(), dict(), int()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", invalid_type, module_list, self.default_options, start=False)
+
+    def test_init_argument_targetType_as_empty_string_should_raise_ValueError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        target_type = ""
+        with self.assertRaises(ValueError) as cm:
+            sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", target_type, module_list, self.default_options, start=False)
+
+    def test_init_argument_moduleList_of_invalid_type_should_raise_TypeError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        invalid_types = [None, "", dict(), int()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", invalid_type, self.default_options, start=False)
+
+    def test_init_argument_moduleList_as_empty_list_should_raise_ValueError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = list()
+
+        with self.assertRaises(ValueError) as cm:
+            sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, dict(), start=False)
+
+    def test_init_argument_globalOpts_of_invalid_type_should_raise_TypeError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        invalid_types = [None, "", list(), int()]
+        for invalid_type in invalid_types:
+            with self.subTest(invalid_type=invalid_type):
+                with self.assertRaises(TypeError) as cm:
+                    sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, invalid_type, start=False)
+
+    def test_init_argument_globalOpts_as_empty_dict_should_raise_ValueError(self):
+        """
+        Test __init__(self, scanName, scanId, scanTarget, targetType, moduleList, globalOpts)
+        """
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        with self.assertRaises(ValueError) as cm:
+            sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, dict(), start=False)
+
+    def test_attribute_scanId_should_return_scan_id_as_a_string(self):
         opts = self.default_options
         opts['__modules__'] = dict()
         scan_id = str(uuid.uuid4())
-        sfscan = SpiderFootScanner("", scan_id, "spiderfoot.net", "IP_ADDRESS", list(), opts, start=False)
+        module_list = ['sfp__stor_db']
+
+        sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, opts, start=False)
         self.assertIsInstance(sfscan, SpiderFootScanner)
 
-        get_id = sfscan.getId()
+        get_id = sfscan.scanId
         self.assertIsInstance(get_id, str)
         self.assertEqual(scan_id, get_id)
 
-    @unittest.skip("todo")
-    def test_start_scan_should_start_a_scan(self):
-        """
-        Test def startScan(self)
-        """
-        self.assertEqual('TBD', 'TBD')
+    def test_attribute_status_should_return_status_as_a_string(self):
+        opts = self.default_options
+        opts['__modules__'] = dict()
+        scan_id = str(uuid.uuid4())
+        module_list = ['sfp__stor_db']
+
+        sfscan = SpiderFootScanner("example scan name", scan_id, "spiderfoot.net", "IP_ADDRESS", module_list, opts, start=False)
+        self.assertIsInstance(sfscan, SpiderFootScanner)
+
+        status = sfscan.status
+        self.assertIsInstance(status, str)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The attributes and functions are not thread safe.

The scanner object is self contained.

Nothing needs to modify a scan from outside of the scan context.

`scanId` and `status` attributes are exposed read-only.