### PR TITLE
requirements: Bump pyOpenSSL>=16.2.0 to pyOpenSSL>=17.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ stem>=1.7.1
 python-whois>=0.7.1
 future
 secure
-pyOpenSSL>=16.2.0
+pyOpenSSL>=17.5.0
 python-docx>=0.8.10
 python-pptx>=0.6.18
 networkx==2.3


### PR DESCRIPTION
```
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| pyopenssl                  | 16.2.0    | <17.5.0                  | 36533    |
+==============================================================================+
| Python Cryptographic Authority pyopenssl version prior to version 17.5.0     |
| contains a CWE-416: Use After Free vulnerability in X509 object handling     |
| that can result in Use after free can lead to possible denial of service or  |
| remote code execution.. This attack appear to be exploitable via Depends on  |
| the calling application and if it retains a reference to the memory.. This   |
| vulnerability appears to have been fixed in 17.5.0.                          |
+==============================================================================+
| pyopenssl                  | 16.2.0    | <17.5.0                  | 36534    |
+==============================================================================+
| Python Cryptographic Authority pyopenssl version Before 17.5.0 contains a    |
| CWE - 401 : Failure to Release Memory Before Removing Last Reference         |
| vulnerability in PKCS #12 Store that can result in Denial of service if      |
| memory runs low or is exhausted.                                             |
+==============================================================================+
```
