### PR TITLE
requirements: Remove 'future' dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ pygexf>=0.2.2
 PyPDF2>=1.26.0
 stem>=1.7.1
 python-whois>=0.7.1
-future
 secure
 pyOpenSSL>=17.5.0
 python-docx>=0.8.10


### PR DESCRIPTION
[future](https://pypi.org/project/future/) is not used for Python 3. `future` is no imported anywhere.