### PR TITLE
sf: remove '_socks6dns' config option

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -80,7 +80,6 @@ sfConfig = {
     '_socks3port': '',
     '_socks4user': '',
     '_socks5pwd': '',
-    '_socks6dns': True,
     '_torctlport': 9051,
     '__logstdout': False
 }
@@ -98,7 +97,6 @@ sfOptdescs = {
     '_socks3port': 'SOCKS Server TCP Port. Usually 1080 for 4/5, 8080 for HTTP and 9050 for TOR.',
     '_socks4user': 'SOCKS Username. Valid only for SOCKS4 and SOCKS5 servers.',
     '_socks5pwd': "SOCKS Password. Valid only for SOCKS5 servers.",
-    '_socks6dns': "Resolve DNS through the SOCKS proxy? When SOCKS/TOR is used this will always be True when resolving to fetch web content. Otherwise, all other DNS resolution goes to your configured DNS server.",
     '_torctlport': "The port TOR is taking control commands on. This is necessary for SpiderFoot to tell TOR to re-circuit when it suspects anonymity is compromised.",
     '_fatalerrors': "Abort the scan when modules encounter exceptions.",
     '_modulesenabled': "Modules enabled for the scan."  # This is a hack to get a description for an option not actually available.

--- a/sfscan.py
+++ b/sfscan.py
@@ -133,8 +133,6 @@ class SpiderFootScanner():
 
         # If a SOCKS server was specified, set it up
         if self.__config['_socks1type']:
-            # TODO: review why socksDns is unused
-            # socksDns = self.__config['_socks6dns']
             socksAddr = self.__config['_socks2addr']
             socksPort = int(self.__config['_socks3port'])
             socksUsername = self.__config['_socks4user'] or ''


### PR DESCRIPTION
Resolves #880

Allowing DNS resolution via the proxy would be a good option have. However, it should removed from now, as this is dead code that does nothing, and offering the option users is misleading.
