### PR TITLE
sf: remove unused '__blocknotif' config option

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -70,7 +70,6 @@ def main():
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp__stor_db.py
+++ b/test/unit/modules/test_sfp__stor_db.py
@@ -15,7 +15,6 @@ class TestModule_stor_db(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp__stor_stdout.py
+++ b/test/unit/modules/test_sfp__stor_stdout.py
@@ -15,7 +15,6 @@ class TestModule_stor_stdout(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_abusech.py
+++ b/test/unit/modules/test_sfp_abusech.py
@@ -15,7 +15,6 @@ class TestModuleabusech(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_abuseipdb.py
+++ b/test/unit/modules/test_sfp_abuseipdb.py
@@ -15,7 +15,6 @@ class TestModuleabuseipdb(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_accounts.py
+++ b/test/unit/modules/test_sfp_accounts.py
@@ -15,7 +15,6 @@ class TestModuleaccounts(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_adblock.py
+++ b/test/unit/modules/test_sfp_adblock.py
@@ -15,7 +15,6 @@ class TestModuleadblock(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_ahmia.py
+++ b/test/unit/modules/test_sfp_ahmia.py
@@ -15,7 +15,6 @@ class TestModuleahmia(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_alienvault.py
+++ b/test/unit/modules/test_sfp_alienvault.py
@@ -15,7 +15,6 @@ class TestModulealienvault(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_alienvaultiprep.py
+++ b/test/unit/modules/test_sfp_alienvaultiprep.py
@@ -15,7 +15,6 @@ class TestModulealienvaultiprep(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_apility.py
+++ b/test/unit/modules/test_sfp_apility.py
@@ -15,7 +15,6 @@ class TestModuleapility(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_archiveorg.py
+++ b/test/unit/modules/test_sfp_archiveorg.py
@@ -15,7 +15,6 @@ class TestModulearchiveorg(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_arin.py
+++ b/test/unit/modules/test_sfp_arin.py
@@ -15,7 +15,6 @@ class TestModulearin(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_azureblobstorage.py
+++ b/test/unit/modules/test_sfp_azureblobstorage.py
@@ -15,7 +15,6 @@ class TestModuleazureblobstorage(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_badipscom.py
+++ b/test/unit/modules/test_sfp_badipscom.py
@@ -15,7 +15,6 @@ class TestModulebadipscom(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_badpackets.py
+++ b/test/unit/modules/test_sfp_badpackets.py
@@ -15,7 +15,6 @@ class TestModulebadpackets(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_bambenek.py
+++ b/test/unit/modules/test_sfp_bambenek.py
@@ -15,7 +15,6 @@ class TestModulebambenek(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_base64.py
+++ b/test/unit/modules/test_sfp_base64.py
@@ -15,7 +15,6 @@ class TestModuleBase64(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_bgpview.py
+++ b/test/unit/modules/test_sfp_bgpview.py
@@ -15,7 +15,6 @@ class TestModulebgpview(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_binaryedge.py
+++ b/test/unit/modules/test_sfp_binaryedge.py
@@ -15,7 +15,6 @@ class TestModulebinaryedge(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_bingsearch.py
+++ b/test/unit/modules/test_sfp_bingsearch.py
@@ -15,7 +15,6 @@ class TestModulebingsearch(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_bingsharedip.py
+++ b/test/unit/modules/test_sfp_bingsharedip.py
@@ -15,7 +15,6 @@ class TestModulebingsharedip(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_binstring.py
+++ b/test/unit/modules/test_sfp_binstring.py
@@ -15,7 +15,6 @@ class TestModuleBinstring(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_bitcoin.py
+++ b/test/unit/modules/test_sfp_bitcoin.py
@@ -15,7 +15,6 @@ class TestModuleBitcoin(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_bitcoinabuse.py
+++ b/test/unit/modules/test_sfp_bitcoinabuse.py
@@ -15,7 +15,6 @@ class TestModuleBitcoinAbuse(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_blockchain.py
+++ b/test/unit/modules/test_sfp_blockchain.py
@@ -15,7 +15,6 @@ class TestModuleblockchain(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_blocklistde.py
+++ b/test/unit/modules/test_sfp_blocklistde.py
@@ -15,7 +15,6 @@ class TestModuleblocklistde(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_botscout.py
+++ b/test/unit/modules/test_sfp_botscout.py
@@ -15,7 +15,6 @@ class TestModulebotscout(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_botvrij.py
+++ b/test/unit/modules/test_sfp_botvrij.py
@@ -15,7 +15,6 @@ class TestModulebotvrij(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_builtwith.py
+++ b/test/unit/modules/test_sfp_builtwith.py
@@ -15,7 +15,6 @@ class TestModulebuiltwith(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_c99.py
+++ b/test/unit/modules/test_sfp_c99.py
@@ -12,7 +12,6 @@ class TestModuleC99(unittest.TestCase):
         "_debug": False,  # Debug
         "__logging": True,  # Logging in general
         "__outputfilter": None,  # Event types to filter from modules' output
-        "__blocknotif": False,  # Block notifications
         "_useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0",  # User-Agent to use for HTTP requests
         "_dnsserver": "",  # Override the default resolver
         "_fetchtimeout": 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_callername.py
+++ b/test/unit/modules/test_sfp_callername.py
@@ -15,7 +15,6 @@ class TestModulecallername(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_censys.py
+++ b/test/unit/modules/test_sfp_censys.py
@@ -15,7 +15,6 @@ class TestModulecensys(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_cinsscore.py
+++ b/test/unit/modules/test_sfp_cinsscore.py
@@ -15,7 +15,6 @@ class TestModulecinsscore(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_circllu.py
+++ b/test/unit/modules/test_sfp_circllu.py
@@ -15,7 +15,6 @@ class TestModulecircllu(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_citadel.py
+++ b/test/unit/modules/test_sfp_citadel.py
@@ -15,7 +15,6 @@ class TestModulecitadel(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_cleanbrowsing.py
+++ b/test/unit/modules/test_sfp_cleanbrowsing.py
@@ -15,7 +15,6 @@ class TestModulecleanbrowsing(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_cleantalk.py
+++ b/test/unit/modules/test_sfp_cleantalk.py
@@ -15,7 +15,6 @@ class TestModulecleantalk(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_clearbit.py
+++ b/test/unit/modules/test_sfp_clearbit.py
@@ -15,7 +15,6 @@ class TestModuleclearbit(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_cloudflaredns.py
+++ b/test/unit/modules/test_sfp_cloudflaredns.py
@@ -15,7 +15,6 @@ class TestModulecloudflaredns(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_coinblocker.py
+++ b/test/unit/modules/test_sfp_coinblocker.py
@@ -15,7 +15,6 @@ class TestModulecoinblocker(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_commoncrawl.py
+++ b/test/unit/modules/test_sfp_commoncrawl.py
@@ -15,7 +15,6 @@ class TestModulecommoncrawl(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_comodo.py
+++ b/test/unit/modules/test_sfp_comodo.py
@@ -15,7 +15,6 @@ class TestModulecomodo(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_company.py
+++ b/test/unit/modules/test_sfp_company.py
@@ -15,7 +15,6 @@ class TestModuleCompany(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_cookie.py
+++ b/test/unit/modules/test_sfp_cookie.py
@@ -15,7 +15,6 @@ class TestModuleCookie(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_countryname.py
+++ b/test/unit/modules/test_sfp_countryname.py
@@ -15,7 +15,6 @@ class TestModuleCountryName(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_creditcard.py
+++ b/test/unit/modules/test_sfp_creditcard.py
@@ -15,7 +15,6 @@ class TestModuleCreditCard(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_crobat_api.py
+++ b/test/unit/modules/test_sfp_crobat_api.py
@@ -15,7 +15,6 @@ class TestModuleCrobat_api(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_crossref.py
+++ b/test/unit/modules/test_sfp_crossref.py
@@ -15,7 +15,6 @@ class TestModulecrossref(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_crt.py
+++ b/test/unit/modules/test_sfp_crt.py
@@ -15,7 +15,6 @@ class TestModulecrt(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_customfeed.py
+++ b/test/unit/modules/test_sfp_customfeed.py
@@ -15,7 +15,6 @@ class TestModulecustomfeed(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_cybercrimetracker.py
+++ b/test/unit/modules/test_sfp_cybercrimetracker.py
@@ -15,7 +15,6 @@ class TestModulecybercrimetracker(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_darksearch.py
+++ b/test/unit/modules/test_sfp_darksearch.py
@@ -15,7 +15,6 @@ class TestModuledarksearch(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_digitaloceanspace.py
+++ b/test/unit/modules/test_sfp_digitaloceanspace.py
@@ -15,7 +15,6 @@ class TestModuledigitaloceanspace(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_dnsbrute.py
+++ b/test/unit/modules/test_sfp_dnsbrute.py
@@ -15,7 +15,6 @@ class TestModulednsbrute(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_dnscommonsrv.py
+++ b/test/unit/modules/test_sfp_dnscommonsrv.py
@@ -15,7 +15,6 @@ class TestModulednscommonsrv(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_dnsgrep.py
+++ b/test/unit/modules/test_sfp_dnsgrep.py
@@ -15,7 +15,6 @@ class TestModulednsgrep(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_dnsneighbor.py
+++ b/test/unit/modules/test_sfp_dnsneighbor.py
@@ -15,7 +15,6 @@ class TestModulednsneighbor(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_dnsraw.py
+++ b/test/unit/modules/test_sfp_dnsraw.py
@@ -15,7 +15,6 @@ class TestModulednsraw(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_dnsresolve.py
+++ b/test/unit/modules/test_sfp_dnsresolve.py
@@ -15,7 +15,6 @@ class TestModuleDnsResolve(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_dnszonexfer.py
+++ b/test/unit/modules/test_sfp_dnszonexfer.py
@@ -15,7 +15,6 @@ class TestModulednszonexfer(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_dronebl.py
+++ b/test/unit/modules/test_sfp_dronebl.py
@@ -15,7 +15,6 @@ class TestModuledronebl(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_duckduckgo.py
+++ b/test/unit/modules/test_sfp_duckduckgo.py
@@ -15,7 +15,6 @@ class TestModuleduckduckgo(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_email.py
+++ b/test/unit/modules/test_sfp_email.py
@@ -15,7 +15,6 @@ class TestModuleEmail(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_emailcrawlr.py
+++ b/test/unit/modules/test_sfp_emailcrawlr.py
@@ -15,7 +15,6 @@ class TestModuleemailcrawlr(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_emailformat.py
+++ b/test/unit/modules/test_sfp_emailformat.py
@@ -15,7 +15,6 @@ class TestModuleemailformat(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_emailrep.py
+++ b/test/unit/modules/test_sfp_emailrep.py
@@ -15,7 +15,6 @@ class TestModuleemailrep(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_emergingthreats.py
+++ b/test/unit/modules/test_sfp_emergingthreats.py
@@ -15,7 +15,6 @@ class TestModuleemergingthreats(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_errors.py
+++ b/test/unit/modules/test_sfp_errors.py
@@ -15,7 +15,6 @@ class TestModuleErrors(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_ethereum.py
+++ b/test/unit/modules/test_sfp_ethereum.py
@@ -15,7 +15,6 @@ class TestModuleEthereum(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_filemeta.py
+++ b/test/unit/modules/test_sfp_filemeta.py
@@ -15,7 +15,6 @@ class TestModuleFilemeta(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_flickr.py
+++ b/test/unit/modules/test_sfp_flickr.py
@@ -15,7 +15,6 @@ class TestModuleflickr(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_fortinet.py
+++ b/test/unit/modules/test_sfp_fortinet.py
@@ -15,7 +15,6 @@ class TestModulefortinet(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_fraudguard.py
+++ b/test/unit/modules/test_sfp_fraudguard.py
@@ -15,7 +15,6 @@ class TestModulefraudguard(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_fringeproject.py
+++ b/test/unit/modules/test_sfp_fringeproject.py
@@ -15,7 +15,6 @@ class TestModulefringeproject(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_fsecure_riddler.py
+++ b/test/unit/modules/test_sfp_fsecure_riddler.py
@@ -15,7 +15,6 @@ class TestModulefsecure_riddler(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_fullcontact.py
+++ b/test/unit/modules/test_sfp_fullcontact.py
@@ -15,7 +15,6 @@ class TestModulefullcontact(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_github.py
+++ b/test/unit/modules/test_sfp_github.py
@@ -15,7 +15,6 @@ class TestModulegithub(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_googlemaps.py
+++ b/test/unit/modules/test_sfp_googlemaps.py
@@ -15,7 +15,6 @@ class TestModulegooglemaps(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_googleobjectstorage.py
+++ b/test/unit/modules/test_sfp_googleobjectstorage.py
@@ -15,7 +15,6 @@ class TestModulegoogleobjectstorage(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_googlesafebrowsing.py
+++ b/test/unit/modules/test_sfp_googlesafebrowsing.py
@@ -15,7 +15,6 @@ class TestModulegooglesafebrowsing(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_googlesearch.py
+++ b/test/unit/modules/test_sfp_googlesearch.py
@@ -15,7 +15,6 @@ class TestModulegooglesearch(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_gravatar.py
+++ b/test/unit/modules/test_sfp_gravatar.py
@@ -15,7 +15,6 @@ class TestModulegravatar(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_greensnow.py
+++ b/test/unit/modules/test_sfp_greensnow.py
@@ -15,7 +15,6 @@ class TestModulegreensnow(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_grep_app.py
+++ b/test/unit/modules/test_sfp_grep_app.py
@@ -15,7 +15,6 @@ class TestModulegrep_app(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_greynoise.py
+++ b/test/unit/modules/test_sfp_greynoise.py
@@ -15,7 +15,6 @@ class TestModulegreynoise(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_h1nobbdde.py
+++ b/test/unit/modules/test_sfp_h1nobbdde.py
@@ -15,7 +15,6 @@ class TestModuleh1nobbdde(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_hackertarget.py
+++ b/test/unit/modules/test_sfp_hackertarget.py
@@ -15,7 +15,6 @@ class TestModulehackertarget(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_hashes.py
+++ b/test/unit/modules/test_sfp_hashes.py
@@ -15,7 +15,6 @@ class TestModuleHashes(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_haveibeenpwned.py
+++ b/test/unit/modules/test_sfp_haveibeenpwned.py
@@ -15,7 +15,6 @@ class TestModulehaveibeenpwned(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_honeypot.py
+++ b/test/unit/modules/test_sfp_honeypot.py
@@ -15,7 +15,6 @@ class TestModulehoneypot(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_hosting.py
+++ b/test/unit/modules/test_sfp_hosting.py
@@ -15,7 +15,6 @@ class TestModuleHosting(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_hostio.py
+++ b/test/unit/modules/test_sfp_hostio.py
@@ -15,7 +15,6 @@ class TestModulehostio(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_hunter.py
+++ b/test/unit/modules/test_sfp_hunter.py
@@ -15,7 +15,6 @@ class TestModulehunter(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_hybrid_analysis.py
+++ b/test/unit/modules/test_sfp_hybrid_analysis.py
@@ -15,7 +15,6 @@ class TestModulehybrid_analysis(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_iban.py
+++ b/test/unit/modules/test_sfp_iban.py
@@ -15,7 +15,6 @@ class TestModuleIban(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_iknowwhatyoudownload.py
+++ b/test/unit/modules/test_sfp_iknowwhatyoudownload.py
@@ -15,7 +15,6 @@ class TestModuleiknowwhatyoudownload(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_instagram.py
+++ b/test/unit/modules/test_sfp_instagram.py
@@ -15,7 +15,6 @@ class TestModuleinstagram(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_intelx.py
+++ b/test/unit/modules/test_sfp_intelx.py
@@ -15,7 +15,6 @@ class TestModuleintelx(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_intfiles.py
+++ b/test/unit/modules/test_sfp_intfiles.py
@@ -15,7 +15,6 @@ class TestModuleintfiles(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_ipinfo.py
+++ b/test/unit/modules/test_sfp_ipinfo.py
@@ -15,7 +15,6 @@ class TestModuleipinfo(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_ipstack.py
+++ b/test/unit/modules/test_sfp_ipstack.py
@@ -15,7 +15,6 @@ class TestModuleipstack(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_isc.py
+++ b/test/unit/modules/test_sfp_isc.py
@@ -15,7 +15,6 @@ class TestModuleisc(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_jsonwhoiscom.py
+++ b/test/unit/modules/test_sfp_jsonwhoiscom.py
@@ -15,7 +15,6 @@ class TestModulejsonwhoiscom(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_junkfiles.py
+++ b/test/unit/modules/test_sfp_junkfiles.py
@@ -15,7 +15,6 @@ class TestModulejunkfiles(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_keybase.py
+++ b/test/unit/modules/test_sfp_keybase.py
@@ -15,7 +15,6 @@ class TestModulekeybase(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_leakix.py
+++ b/test/unit/modules/test_sfp_leakix.py
@@ -15,7 +15,6 @@ class TestModuleleakix(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_maltiverse.py
+++ b/test/unit/modules/test_sfp_maltiverse.py
@@ -15,7 +15,6 @@ class TestModulemaltiverse(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_malwaredomainlist.py
+++ b/test/unit/modules/test_sfp_malwaredomainlist.py
@@ -15,7 +15,6 @@ class TestModulemalwaredomainlist(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_malwaredomains.py
+++ b/test/unit/modules/test_sfp_malwaredomains.py
@@ -15,7 +15,6 @@ class TestModulemalwaredomains(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_malwarepatrol.py
+++ b/test/unit/modules/test_sfp_malwarepatrol.py
@@ -15,7 +15,6 @@ class TestModulemalwarepatrol(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_metadefender.py
+++ b/test/unit/modules/test_sfp_metadefender.py
@@ -15,7 +15,6 @@ class TestModulemetadefender(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_mnemonic.py
+++ b/test/unit/modules/test_sfp_mnemonic.py
@@ -15,7 +15,6 @@ class TestModulemnemonic(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_multiproxy.py
+++ b/test/unit/modules/test_sfp_multiproxy.py
@@ -15,7 +15,6 @@ class TestModulemultiproxy(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_myspace.py
+++ b/test/unit/modules/test_sfp_myspace.py
@@ -15,7 +15,6 @@ class TestModulemyspace(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_names.py
+++ b/test/unit/modules/test_sfp_names.py
@@ -15,7 +15,6 @@ class TestModuleNames(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_networksdb.py
+++ b/test/unit/modules/test_sfp_networksdb.py
@@ -15,7 +15,6 @@ class TestModulenetworksdb(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_neutrinoapi.py
+++ b/test/unit/modules/test_sfp_neutrinoapi.py
@@ -15,7 +15,6 @@ class TestModuleneutrinoapi(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_norton.py
+++ b/test/unit/modules/test_sfp_norton.py
@@ -15,7 +15,6 @@ class TestModulenorton(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_numverify.py
+++ b/test/unit/modules/test_sfp_numverify.py
@@ -15,7 +15,6 @@ class TestModulenumverify(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_onioncity.py
+++ b/test/unit/modules/test_sfp_onioncity.py
@@ -15,7 +15,6 @@ class TestModuleonioncity(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_onionsearchengine.py
+++ b/test/unit/modules/test_sfp_onionsearchengine.py
@@ -15,7 +15,6 @@ class TestModuleonionsearchengine(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_onyphe.py
+++ b/test/unit/modules/test_sfp_onyphe.py
@@ -15,7 +15,6 @@ class TestModuleOnyphe(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_open_passive_dns_database.py
+++ b/test/unit/modules/test_sfp_open_passive_dns_database.py
@@ -15,7 +15,6 @@ class TestModuleopen_passive_dns_database(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_openbugbounty.py
+++ b/test/unit/modules/test_sfp_openbugbounty.py
@@ -15,7 +15,6 @@ class TestModuleopenbugbounty(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_opencorporates.py
+++ b/test/unit/modules/test_sfp_opencorporates.py
@@ -15,7 +15,6 @@ class TestModuleopencorporates(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_opendns.py
+++ b/test/unit/modules/test_sfp_opendns.py
@@ -15,7 +15,6 @@ class TestModuleopendns(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_openphish.py
+++ b/test/unit/modules/test_sfp_openphish.py
@@ -15,7 +15,6 @@ class TestModuleopenphish(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_openstreetmap.py
+++ b/test/unit/modules/test_sfp_openstreetmap.py
@@ -15,7 +15,6 @@ class TestModuleopenstreetmap(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_pageinfo.py
+++ b/test/unit/modules/test_sfp_pageinfo.py
@@ -15,7 +15,6 @@ class TestModulePageInfo(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_pastebin.py
+++ b/test/unit/modules/test_sfp_pastebin.py
@@ -15,7 +15,6 @@ class TestModulepastebin(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_pgp.py
+++ b/test/unit/modules/test_sfp_pgp.py
@@ -15,7 +15,6 @@ class TestModulepgp(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_phishstats.py
+++ b/test/unit/modules/test_sfp_phishstats.py
@@ -15,7 +15,6 @@ class TestModulephishstats(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_phishtank.py
+++ b/test/unit/modules/test_sfp_phishtank.py
@@ -15,7 +15,6 @@ class TestModulephishtank(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_phone.py
+++ b/test/unit/modules/test_sfp_phone.py
@@ -15,7 +15,6 @@ class TestModulePhone(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_portscan_tcp.py
+++ b/test/unit/modules/test_sfp_portscan_tcp.py
@@ -15,7 +15,6 @@ class TestModuleportscan_tcp(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_psbdmp.py
+++ b/test/unit/modules/test_sfp_psbdmp.py
@@ -15,7 +15,6 @@ class TestModulepsbdmp(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_pulsedive.py
+++ b/test/unit/modules/test_sfp_pulsedive.py
@@ -15,7 +15,6 @@ class TestModulepulsedive(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_quad9.py
+++ b/test/unit/modules/test_sfp_quad9.py
@@ -15,7 +15,6 @@ class TestModulequad9(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_recondev.py
+++ b/test/unit/modules/test_sfp_recondev.py
@@ -15,7 +15,6 @@ class TestModulerecondev(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_ripe.py
+++ b/test/unit/modules/test_sfp_ripe.py
@@ -15,7 +15,6 @@ class TestModuleripe(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_riskiq.py
+++ b/test/unit/modules/test_sfp_riskiq.py
@@ -15,7 +15,6 @@ class TestModuleriskiq(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_robtex.py
+++ b/test/unit/modules/test_sfp_robtex.py
@@ -15,7 +15,6 @@ class TestModulerobtex(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_s3bucket.py
+++ b/test/unit/modules/test_sfp_s3bucket.py
@@ -15,7 +15,6 @@ class TestModules3bucket(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_scylla.py
+++ b/test/unit/modules/test_sfp_scylla.py
@@ -15,7 +15,6 @@ class TestModulescylla(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_securitytrails.py
+++ b/test/unit/modules/test_sfp_securitytrails.py
@@ -15,7 +15,6 @@ class TestModulesecuritytrails(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_shodan.py
+++ b/test/unit/modules/test_sfp_shodan.py
@@ -15,7 +15,6 @@ class TestModuleshodan(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_similar.py
+++ b/test/unit/modules/test_sfp_similar.py
@@ -15,7 +15,6 @@ class TestModulesimilar(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_skymem.py
+++ b/test/unit/modules/test_sfp_skymem.py
@@ -15,7 +15,6 @@ class TestModuleskymem(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_slideshare.py
+++ b/test/unit/modules/test_sfp_slideshare.py
@@ -15,7 +15,6 @@ class TestModuleslideshare(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_snov.py
+++ b/test/unit/modules/test_sfp_snov.py
@@ -15,7 +15,6 @@ class TestModulesnov(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_social.py
+++ b/test/unit/modules/test_sfp_social.py
@@ -15,7 +15,6 @@ class TestModulesocial(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_socialprofiles.py
+++ b/test/unit/modules/test_sfp_socialprofiles.py
@@ -15,7 +15,6 @@ class TestModulesocialprofiles(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_sorbs.py
+++ b/test/unit/modules/test_sfp_sorbs.py
@@ -15,7 +15,6 @@ class TestModulesorbs(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_spamcop.py
+++ b/test/unit/modules/test_sfp_spamcop.py
@@ -15,7 +15,6 @@ class TestModulespamcop(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_spamhaus.py
+++ b/test/unit/modules/test_sfp_spamhaus.py
@@ -15,7 +15,6 @@ class TestModulespamhaus(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_spider.py
+++ b/test/unit/modules/test_sfp_spider.py
@@ -15,7 +15,6 @@ class TestModulespider(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_spur.py
+++ b/test/unit/modules/test_sfp_spur.py
@@ -15,7 +15,6 @@ class TestModulespur(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_spyonweb.py
+++ b/test/unit/modules/test_sfp_spyonweb.py
@@ -15,7 +15,6 @@ class TestModulespyonweb(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_spyse.py
+++ b/test/unit/modules/test_sfp_spyse.py
@@ -15,7 +15,6 @@ class TestModulespyse(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_sslcert.py
+++ b/test/unit/modules/test_sfp_sslcert.py
@@ -15,7 +15,6 @@ class TestModulesslcert(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_strangeheaders.py
+++ b/test/unit/modules/test_sfp_strangeheaders.py
@@ -15,7 +15,6 @@ class TestModuleStrangeHeaders(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_subdomain_takeover.py
+++ b/test/unit/modules/test_sfp_subdomain_takeover.py
@@ -15,7 +15,6 @@ class TestModulesubdomain_takeover(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_talosintel.py
+++ b/test/unit/modules/test_sfp_talosintel.py
@@ -15,7 +15,6 @@ class TestModuletalosintel(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_template.py
+++ b/test/unit/modules/test_sfp_template.py
@@ -15,7 +15,6 @@ class TestModuletemplate(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_threatcrowd.py
+++ b/test/unit/modules/test_sfp_threatcrowd.py
@@ -15,7 +15,6 @@ class TestModulethreatcrowd(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_threatminer.py
+++ b/test/unit/modules/test_sfp_threatminer.py
@@ -15,7 +15,6 @@ class TestModulethreatminer(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_tldsearch.py
+++ b/test/unit/modules/test_sfp_tldsearch.py
@@ -15,7 +15,6 @@ class TestModuletldsearch(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_tool_cmseek.py
+++ b/test/unit/modules/test_sfp_tool_cmseek.py
@@ -15,7 +15,6 @@ class TestModuleCmseek(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_tool_dnstwist.py
+++ b/test/unit/modules/test_sfp_tool_dnstwist.py
@@ -15,7 +15,6 @@ class TestModuletool_dnstwist(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_tool_nmap.py
+++ b/test/unit/modules/test_sfp_tool_nmap.py
@@ -15,7 +15,6 @@ class TestModuletool_nmap(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_tool_whatweb.py
+++ b/test/unit/modules/test_sfp_tool_whatweb.py
@@ -15,7 +15,6 @@ class TestModuleWhatweb(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_torch.py
+++ b/test/unit/modules/test_sfp_torch.py
@@ -15,7 +15,6 @@ class TestModuletorch(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_torexits.py
+++ b/test/unit/modules/test_sfp_torexits.py
@@ -15,7 +15,6 @@ class TestModuletorexits(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_totalhash.py
+++ b/test/unit/modules/test_sfp_totalhash.py
@@ -15,7 +15,6 @@ class TestModuletotalhash(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_twilio.py
+++ b/test/unit/modules/test_sfp_twilio.py
@@ -15,7 +15,6 @@ class TestModuletwilio(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_twitter.py
+++ b/test/unit/modules/test_sfp_twitter.py
@@ -15,7 +15,6 @@ class TestModuletwitter(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_uceprotect.py
+++ b/test/unit/modules/test_sfp_uceprotect.py
@@ -15,7 +15,6 @@ class TestModuleuceprotect(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_urlscan.py
+++ b/test/unit/modules/test_sfp_urlscan.py
@@ -15,7 +15,6 @@ class TestModuleurlscan(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_venmo.py
+++ b/test/unit/modules/test_sfp_venmo.py
@@ -15,7 +15,6 @@ class TestModulevenmo(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_viewdns.py
+++ b/test/unit/modules/test_sfp_viewdns.py
@@ -15,7 +15,6 @@ class TestModuleviewdns(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_virustotal.py
+++ b/test/unit/modules/test_sfp_virustotal.py
@@ -15,7 +15,6 @@ class TestModulevirustotal(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_voipbl.py
+++ b/test/unit/modules/test_sfp_voipbl.py
@@ -15,7 +15,6 @@ class TestModulevoipbl(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_vxvault.py
+++ b/test/unit/modules/test_sfp_vxvault.py
@@ -15,7 +15,6 @@ class TestModulevxvault(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_watchguard.py
+++ b/test/unit/modules/test_sfp_watchguard.py
@@ -15,7 +15,6 @@ class TestModulewatchguard(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_webanalytics.py
+++ b/test/unit/modules/test_sfp_webanalytics.py
@@ -15,7 +15,6 @@ class TestModuleWebAnalytics(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_webframework.py
+++ b/test/unit/modules/test_sfp_webframework.py
@@ -15,7 +15,6 @@ class TestModuleWebFramework(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_webserver.py
+++ b/test/unit/modules/test_sfp_webserver.py
@@ -15,7 +15,6 @@ class TestModuleWebserver(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_whatcms.py
+++ b/test/unit/modules/test_sfp_whatcms.py
@@ -15,7 +15,6 @@ class TestModuleWhatCMS(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_whois.py
+++ b/test/unit/modules/test_sfp_whois.py
@@ -15,7 +15,6 @@ class TestModulewhois(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_whoisology.py
+++ b/test/unit/modules/test_sfp_whoisology.py
@@ -15,7 +15,6 @@ class TestModulewhoisology(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_whoxy.py
+++ b/test/unit/modules/test_sfp_whoxy.py
@@ -15,7 +15,6 @@ class TestModulewhoxy(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_wigle.py
+++ b/test/unit/modules/test_sfp_wigle.py
@@ -15,7 +15,6 @@ class TestModulewigle(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_wikileaks.py
+++ b/test/unit/modules/test_sfp_wikileaks.py
@@ -15,7 +15,6 @@ class TestModulewikileaks(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_wikipediaedits.py
+++ b/test/unit/modules/test_sfp_wikipediaedits.py
@@ -15,7 +15,6 @@ class TestModulewikipediaedits(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_xforce.py
+++ b/test/unit/modules/test_sfp_xforce.py
@@ -15,7 +15,6 @@ class TestModulexforce(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_yandexdns.py
+++ b/test/unit/modules/test_sfp_yandexdns.py
@@ -15,7 +15,6 @@ class TestModuleyandexdns(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/modules/test_sfp_zoneh.py
+++ b/test/unit/modules/test_sfp_zoneh.py
@@ -15,7 +15,6 @@ class TestModulezoneh(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -14,7 +14,6 @@ class TestSpiderFoot(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/test_spiderfoot_module_loading.py
+++ b/test/unit/test_spiderfoot_module_loading.py
@@ -14,7 +14,6 @@ class TestSpiderFootModuleLoading(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver
         '_fetchtimeout': 5,  # number of seconds before giving up on a fetch

--- a/test/unit/test_spiderfootdb.py
+++ b/test/unit/test_spiderfootdb.py
@@ -12,7 +12,6 @@ class TestSpiderFootDb(unittest.TestCase):
         '_debug': False,
         '__logging': True,
         '__outputfilter': None,
-        '__blocknotif': False,
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',
         '_dnsserver': '',
         '_fetchtimeout': 5,

--- a/test/unit/test_spiderfootplugin.py
+++ b/test/unit/test_spiderfootplugin.py
@@ -13,7 +13,6 @@ class TestSpiderFootPlugin(unittest.TestCase):
         '_debug': False,  # Debug
         '__logging': True,  # Logging in general
         '__outputfilter': None,  # Event types to filter from modules' output
-        '__blocknotif': False,  # Block notifications
         '_fatalerrors': False,
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
         '_dnsserver': '',  # Override the default resolver

--- a/test/unit/test_spiderfootscanner.py
+++ b/test/unit/test_spiderfootscanner.py
@@ -13,7 +13,6 @@ class TestSpiderFootScanner(unittest.TestCase):
         '_debug': False,
         '__logging': True,
         '__outputfilter': None,
-        '__blocknotif': False,
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',
         '_dnsserver': '',
         '_fetchtimeout': 5,

--- a/test/unit/test_spiderfootwebui.py
+++ b/test/unit/test_spiderfootwebui.py
@@ -16,7 +16,6 @@ class TestSpiderFootWebUiRoutes(helper.CPWebCase):
             '_debug': False,  # Debug
             '__logging': True,  # Logging in general
             '__outputfilter': None,  # Event types to filter from modules' output
-            '__blocknotif': False,  # Block notifications
             '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
             '_dnsserver': '',  # Override the default resolver
             '_fetchtimeout': 5,  # number of seconds before giving up on a fetch
@@ -305,7 +304,6 @@ class TestSpiderFootWebUi(unittest.TestCase):
         '_debug': False,
         '__logging': True,
         '__outputfilter': None,
-        '__blocknotif': False,
         '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',
         '_dnsserver': '',
         '_fetchtimeout': 5,


### PR DESCRIPTION
This config option is dead code that does nothing and offering the option to users is misleading.