### PR TITLE
tests: update module tests

### DIFF
--- a/test/unit/modules/test_sfp_abuseipdb.py
+++ b/test/unit/modules/test_sfp_abuseipdb.py
@@ -54,8 +54,7 @@ class TestModuleabuseipdb(unittest.TestCase):
         module = sfp_abuseipdb()
         self.assertIsInstance(module.producedEvents(), list)
 
-    @unittest.skip("todo")
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -78,3 +77,4 @@ class TestModuleabuseipdb(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_apility.py
+++ b/test/unit/modules/test_sfp_apility.py
@@ -54,7 +54,7 @@ class TestModuleapility(unittest.TestCase):
         module = sfp_apility()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleapility(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_badpackets.py
+++ b/test/unit/modules/test_sfp_badpackets.py
@@ -54,7 +54,7 @@ class TestModulebadpackets(unittest.TestCase):
         module = sfp_badpackets()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """

--- a/test/unit/modules/test_sfp_binaryedge.py
+++ b/test/unit/modules/test_sfp_binaryedge.py
@@ -54,7 +54,7 @@ class TestModulebinaryedge(unittest.TestCase):
         module = sfp_binaryedge()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulebinaryedge(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_bingsearch.py
+++ b/test/unit/modules/test_sfp_bingsearch.py
@@ -54,7 +54,7 @@ class TestModulebingsearch(unittest.TestCase):
         module = sfp_bingsearch()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulebingsearch(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_bitcoinabuse.py
+++ b/test/unit/modules/test_sfp_bitcoinabuse.py
@@ -54,7 +54,7 @@ class TestModuleBitcoinAbuse(unittest.TestCase):
         module = sfp_bitcoinabuse()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleBitcoinAbuse(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_builtwith.py
+++ b/test/unit/modules/test_sfp_builtwith.py
@@ -54,7 +54,7 @@ class TestModulebuiltwith(unittest.TestCase):
         module = sfp_builtwith()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulebuiltwith(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_c99.py
+++ b/test/unit/modules/test_sfp_c99.py
@@ -48,7 +48,7 @@ class TestModuleC99(unittest.TestCase):
         module = sfp_c99()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         sf = SpiderFoot(self.default_options)
 
         module = sfp_c99()
@@ -68,3 +68,4 @@ class TestModuleC99(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_callername.py
+++ b/test/unit/modules/test_sfp_callername.py
@@ -55,7 +55,6 @@ class TestModulecallername(unittest.TestCase):
         module = sfp_callername()
         self.assertIsInstance(module.producedEvents(), list)
 
-    @unittest.skip("todo")
     def test_handleEvent(self):
         """
         Test handleEvent(self, event)

--- a/test/unit/modules/test_sfp_censys.py
+++ b/test/unit/modules/test_sfp_censys.py
@@ -55,8 +55,7 @@ class TestModulecensys(unittest.TestCase):
         module = sfp_censys()
         self.assertIsInstance(module.producedEvents(), list)
 
-    @unittest.skip("todo")
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -79,3 +78,4 @@ class TestModulecensys(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_cinsscore.py
+++ b/test/unit/modules/test_sfp_cinsscore.py
@@ -33,7 +33,6 @@ class TestModulecinsscore(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_cinsscore()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_circllu.py
+++ b/test/unit/modules/test_sfp_circllu.py
@@ -55,8 +55,7 @@ class TestModulecircllu(unittest.TestCase):
         module = sfp_circllu()
         self.assertIsInstance(module.producedEvents(), list)
 
-    @unittest.skip("todo")
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -79,3 +78,4 @@ class TestModulecircllu(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_citadel.py
+++ b/test/unit/modules/test_sfp_citadel.py
@@ -33,7 +33,6 @@ class TestModulecitadel(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_citadel()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_cleanbrowsing.py
+++ b/test/unit/modules/test_sfp_cleanbrowsing.py
@@ -33,7 +33,6 @@ class TestModulecleanbrowsing(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_cleanbrowsing()
         self.assertEqual(len(module.opts), len(module.optdescs))
@@ -55,7 +54,6 @@ class TestModulecleanbrowsing(unittest.TestCase):
         module = sfp_cleanbrowsing()
         self.assertIsInstance(module.producedEvents(), list)
 
-    @unittest.skip("todo")
     def test_handleEvent(self):
         """
         Test handleEvent(self, event)

--- a/test/unit/modules/test_sfp_cleantalk.py
+++ b/test/unit/modules/test_sfp_cleantalk.py
@@ -33,7 +33,6 @@ class TestModulecleantalk(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_cleantalk()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_clearbit.py
+++ b/test/unit/modules/test_sfp_clearbit.py
@@ -33,7 +33,6 @@ class TestModuleclearbit(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_clearbit()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_cloudflaredns.py
+++ b/test/unit/modules/test_sfp_cloudflaredns.py
@@ -33,7 +33,6 @@ class TestModulecloudflaredns(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_cloudflaredns()
         self.assertEqual(len(module.opts), len(module.optdescs))
@@ -55,7 +54,6 @@ class TestModulecloudflaredns(unittest.TestCase):
         module = sfp_cloudflaredns()
         self.assertIsInstance(module.producedEvents(), list)
 
-    @unittest.skip("todo")
     def test_handleEvent(self):
         """
         Test handleEvent(self, event)

--- a/test/unit/modules/test_sfp_coinblocker.py
+++ b/test/unit/modules/test_sfp_coinblocker.py
@@ -33,7 +33,6 @@ class TestModulecoinblocker(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_coinblocker()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_commoncrawl.py
+++ b/test/unit/modules/test_sfp_commoncrawl.py
@@ -33,7 +33,6 @@ class TestModulecommoncrawl(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_commoncrawl()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_comodo.py
+++ b/test/unit/modules/test_sfp_comodo.py
@@ -33,7 +33,6 @@ class TestModulecomodo(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_comodo()
         self.assertEqual(len(module.opts), len(module.optdescs))
@@ -55,7 +54,6 @@ class TestModulecomodo(unittest.TestCase):
         module = sfp_comodo()
         self.assertIsInstance(module.producedEvents(), list)
 
-    @unittest.skip("todo")
     def test_handleEvent(self):
         """
         Test handleEvent(self, event)

--- a/test/unit/modules/test_sfp_crossref.py
+++ b/test/unit/modules/test_sfp_crossref.py
@@ -33,7 +33,6 @@ class TestModulecrossref(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_crossref()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_crt.py
+++ b/test/unit/modules/test_sfp_crt.py
@@ -33,7 +33,6 @@ class TestModulecrt(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_crt()
         self.assertEqual(len(module.opts), len(module.optdescs))

--- a/test/unit/modules/test_sfp_emailrep.py
+++ b/test/unit/modules/test_sfp_emailrep.py
@@ -33,7 +33,6 @@ class TestModuleemailrep(unittest.TestCase):
         '__logstdout': False
     }
 
-    @unittest.skip("todo")
     def test_opts(self):
         module = sfp_emailrep()
         self.assertEqual(len(module.opts), len(module.optdescs))
@@ -56,7 +55,7 @@ class TestModuleemailrep(unittest.TestCase):
         self.assertIsInstance(module.producedEvents(), list)
 
     @unittest.skip("todo")
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """

--- a/test/unit/modules/test_sfp_fullcontact.py
+++ b/test/unit/modules/test_sfp_fullcontact.py
@@ -54,7 +54,7 @@ class TestModulefullcontact(unittest.TestCase):
         module = sfp_fullcontact()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulefullcontact(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_googlemaps.py
+++ b/test/unit/modules/test_sfp_googlemaps.py
@@ -54,7 +54,7 @@ class TestModulegooglemaps(unittest.TestCase):
         module = sfp_googlemaps()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulegooglemaps(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_googlesearch.py
+++ b/test/unit/modules/test_sfp_googlesearch.py
@@ -54,7 +54,7 @@ class TestModulegooglesearch(unittest.TestCase):
         module = sfp_googlesearch()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulegooglesearch(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_greynoise.py
+++ b/test/unit/modules/test_sfp_greynoise.py
@@ -54,7 +54,7 @@ class TestModulegreynoise(unittest.TestCase):
         module = sfp_greynoise()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulegreynoise(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_hostio.py
+++ b/test/unit/modules/test_sfp_hostio.py
@@ -55,8 +55,7 @@ class TestModulehostio(unittest.TestCase):
         module = sfp_hostio()
         self.assertIsInstance(module.producedEvents(), list)
 
-    @unittest.skip("todo")
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -66,7 +65,7 @@ class TestModulehostio(unittest.TestCase):
         module.setup(sf, dict())
 
         target_value = 'example target value'
-        target_type = 'DOMAIN_NAME'
+        target_type = 'INTERNET_NAME'
         target = SpiderFootTarget(target_value, target_type)
         module.setTarget(target)
 
@@ -79,3 +78,4 @@ class TestModulehostio(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_hunter.py
+++ b/test/unit/modules/test_sfp_hunter.py
@@ -54,7 +54,7 @@ class TestModulehunter(unittest.TestCase):
         module = sfp_hunter()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulehunter(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_intelx.py
+++ b/test/unit/modules/test_sfp_intelx.py
@@ -54,7 +54,7 @@ class TestModuleintelx(unittest.TestCase):
         module = sfp_intelx()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleintelx(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_ipstack.py
+++ b/test/unit/modules/test_sfp_ipstack.py
@@ -54,7 +54,7 @@ class TestModuleipstack(unittest.TestCase):
         module = sfp_ipstack()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleipstack(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_jsonwhoiscom.py
+++ b/test/unit/modules/test_sfp_jsonwhoiscom.py
@@ -54,7 +54,7 @@ class TestModulejsonwhoiscom(unittest.TestCase):
         module = sfp_jsonwhoiscom()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """

--- a/test/unit/modules/test_sfp_malwarepatrol.py
+++ b/test/unit/modules/test_sfp_malwarepatrol.py
@@ -54,7 +54,7 @@ class TestModulemalwarepatrol(unittest.TestCase):
         module = sfp_malwarepatrol()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """

--- a/test/unit/modules/test_sfp_neutrinoapi.py
+++ b/test/unit/modules/test_sfp_neutrinoapi.py
@@ -54,7 +54,7 @@ class TestModuleneutrinoapi(unittest.TestCase):
         module = sfp_neutrinoapi()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleneutrinoapi(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_onyphe.py
+++ b/test/unit/modules/test_sfp_onyphe.py
@@ -54,7 +54,7 @@ class TestModuleOnyphe(unittest.TestCase):
         module = sfp_onyphe()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleOnyphe(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_riskiq.py
+++ b/test/unit/modules/test_sfp_riskiq.py
@@ -54,7 +54,7 @@ class TestModuleriskiq(unittest.TestCase):
         module = sfp_riskiq()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleriskiq(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_shodan.py
+++ b/test/unit/modules/test_sfp_shodan.py
@@ -54,7 +54,7 @@ class TestModuleshodan(unittest.TestCase):
         module = sfp_shodan()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleshodan(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_snov.py
+++ b/test/unit/modules/test_sfp_snov.py
@@ -54,7 +54,7 @@ class TestModulesnov(unittest.TestCase):
         module = sfp_snov()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulesnov(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_spur.py
+++ b/test/unit/modules/test_sfp_spur.py
@@ -54,7 +54,7 @@ class TestModulespur(unittest.TestCase):
         module = sfp_spur()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulespur(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_twilio.py
+++ b/test/unit/modules/test_sfp_twilio.py
@@ -54,7 +54,7 @@ class TestModuletwilio(unittest.TestCase):
         module = sfp_twilio()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """

--- a/test/unit/modules/test_sfp_viewdns.py
+++ b/test/unit/modules/test_sfp_viewdns.py
@@ -54,7 +54,7 @@ class TestModuleviewdns(unittest.TestCase):
         module = sfp_viewdns()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleviewdns(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_virustotal.py
+++ b/test/unit/modules/test_sfp_virustotal.py
@@ -54,7 +54,7 @@ class TestModulevirustotal(unittest.TestCase):
         module = sfp_virustotal()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulevirustotal(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_whatcms.py
+++ b/test/unit/modules/test_sfp_whatcms.py
@@ -54,7 +54,7 @@ class TestModuleWhatCMS(unittest.TestCase):
         module = sfp_whatcms()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModuleWhatCMS(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_whoisology.py
+++ b/test/unit/modules/test_sfp_whoisology.py
@@ -54,7 +54,7 @@ class TestModulewhoisology(unittest.TestCase):
         module = sfp_whoisology()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulewhoisology(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/modules/test_sfp_wigle.py
+++ b/test/unit/modules/test_sfp_wigle.py
@@ -54,7 +54,7 @@ class TestModulewigle(unittest.TestCase):
         module = sfp_wigle()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """

--- a/test/unit/modules/test_sfp_xforce.py
+++ b/test/unit/modules/test_sfp_xforce.py
@@ -54,7 +54,7 @@ class TestModulexforce(unittest.TestCase):
         module = sfp_xforce()
         self.assertIsInstance(module.producedEvents(), list)
 
-    def test_handleEvent(self):
+    def test_handleEvent_no_api_key_should_set_errorState(self):
         """
         Test handleEvent(self, event)
         """
@@ -77,3 +77,4 @@ class TestModulexforce(unittest.TestCase):
         result = module.handleEvent(evt)
 
         self.assertIsNone(result)
+        self.assertTrue(module.errorState)

--- a/test/unit/test_sf.py
+++ b/test/unit/test_sf.py
@@ -120,7 +120,3 @@ class TestSf(unittest.TestCase):
         ]
         for output in expected_output:
             self.assertIn(bytes(output, 'utf-8'), out)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -1514,7 +1514,3 @@ class TestSpiderFoot(unittest.TestCase):
 
         sf.bingIterate(None, None)
         self.assertEqual('TBD', 'TBD')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/unit/test_spiderfootcli.py
+++ b/test/unit/test_spiderfootcli.py
@@ -567,7 +567,3 @@ class TestSpiderFootCli(unittest.TestCase):
         sfcli = SpiderFootCli()
         do_eof = sfcli.do_EOF(None)
         self.assertTrue(do_eof)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/unit/test_spiderfootdb.py
+++ b/test/unit/test_spiderfootdb.py
@@ -1268,7 +1268,3 @@ class TestSpiderFootDb(unittest.TestCase):
             with self.subTest(invalid_type=invalid_type):
                 with self.assertRaises(TypeError):
                     sfdb.scanElementChildrenAll(instance_id, invalid_type)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/unit/test_spiderfootevent.py
+++ b/test/unit/test_spiderfootevent.py
@@ -349,7 +349,3 @@ class TestSpiderFootEvent(unittest.TestCase):
         evt_hash = evt.getHash()
 
         self.assertIsInstance(evt_hash, str)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/unit/test_spiderfootplugin.py
+++ b/test/unit/test_spiderfootplugin.py
@@ -305,7 +305,3 @@ class TestSpiderFootPlugin(unittest.TestCase):
         sfp = SpiderFootPlugin()
 
         sfp.start()
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/unit/test_spiderfootscanner.py
+++ b/test/unit/test_spiderfootscanner.py
@@ -215,7 +215,3 @@ class TestSpiderFootScanner(unittest.TestCase):
 
         status = sfscan.status
         self.assertIsInstance(status, str)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/unit/test_spiderfoottarget.py
+++ b/test/unit/test_spiderfoottarget.py
@@ -327,7 +327,3 @@ class TestSpiderFootTarget(unittest.TestCase):
 
         matches = target.matches("")
         self.assertFalse(matches)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/unit/test_spiderfootwebui.py
+++ b/test/unit/test_spiderfootwebui.py
@@ -803,7 +803,3 @@ class TestSpiderFootWebUi(unittest.TestCase):
         sfwebui = SpiderFootWebUi(self.default_web_options, opts)
         scan_element_type_discovery = sfwebui.scanelementtypediscovery(None, None)
         self.assertIsInstance(scan_element_type_discovery, str)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
The one test failure is due to a bug in one module, which has been resolved in #998 (which has not yet been merged).

```
=================================== FAILURES ===================================

____ TestModuleabuseipdb.test_handleEvent_no_api_key_should_set_errorState _____

self = <test.unit.modules.test_sfp_abuseipdb.TestModuleabuseipdb testMethod=test_handleEvent_no_api_key_should_set_errorState>

    def test_handleEvent_no_api_key_should_set_errorState(self):

        """

        Test handleEvent(self, event)

        """

        sf = SpiderFoot(self.default_options)

    

        module = sfp_abuseipdb()

        module.setup(sf, dict())

    

        target_value = 'example target value'

        target_type = 'IP_ADDRESS'

        target = SpiderFootTarget(target_value, target_type)

        module.setTarget(target)

    

        event_type = 'ROOT'

        event_data = 'example data'

        event_module = ''

        source_event = ''

        evt = SpiderFootEvent(event_type, event_data, event_module, source_event)

    

>       result = module.handleEvent(evt)

test/unit/modules/test_sfp_abuseipdb.py:77: 

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <modules.sfp_abuseipdb.sfp_abuseipdb object at 0x7f1def0cd1f0>

event = <spiderfoot.event.SpiderFootEvent object at 0x7f1de8036130>

    def handleEvent(self, event):

        eventName = event.eventType

        srcModuleName = event.module

        eventData = event.data

    

        self.sf.debug(f"Received event, {eventName}, from {srcModuleName}")

    

        if eventData in self.results:

            self.sf.debug(f"Skipping {eventData}, already checked.")

            return None

    

        self.results[eventData] = True

    

        if eventName == 'AFFILIATE_IPADDR' \

                and not self.opts.get('checkaffiliates', False):

            return None

        if eventName == 'NETBLOCK_OWNER' and not self.opts.get('checknetblocks', False):

            return None

        if eventName == 'NETBLOCK_MEMBER' and not self.opts.get('checksubnets', False):

            return None

    

        for check in list(malchecks.keys()):

            cid = malchecks[check]['id']

            if eventName in ['IP_ADDRESS', 'AFFILIATE_IPADDR']:

                typeId = 'ip'

                if eventName == 'IP_ADDRESS':

                    evtType = 'MALICIOUS_IPADDR'

                else:

                    evtType = 'MALICIOUS_AFFILIATE_IPADDR'

    

            if eventName == 'NETBLOCK_OWNER':

                typeId = 'netblock'

                evtType = 'MALICIOUS_NETBLOCK'

            if eventName == 'NETBLOCK_MEMBER':

                typeId = 'netblock'

                evtType = 'MALICIOUS_SUBNET'

    

>           url = self.lookupItem(cid, typeId, eventData)

E           UnboundLocalError: local variable 'typeId' referenced before assignment

modules/sfp_abuseipdb.py:236: UnboundLocalError
```