### PR TITLE
sfwebui: disable logging to screen

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -444,6 +444,7 @@ def start_web_server(sfWebUiConfig, sfConfig):
     web_root = sfWebUiConfig.get('root', '/')
 
     cherrypy.config.update({
+        'log.screen': False,
         'server.socket_host': web_host,
         'server.socket_port': int(web_port)
     })


### PR DESCRIPTION
Cherrypy already uses the existing configured log objects. No need to duplicate logs also to `stdout`.
