### PR TITLE
Remove emit() from the template

### DIFF
--- a/modules/sfp_ipregistry.py
+++ b/modules/sfp_ipregistry.py
@@ -89,10 +89,9 @@ class sfp_ipregistry(SpiderFootPlugin):
 
         return info
 
-    def emit(self, etype, data, pevent, notify=True):
+    def emit(self, etype, data, pevent):
         evt = SpiderFootEvent(etype, data, self.__name__, pevent)
-        if notify:
-            self.notifyListeners(evt)
+        self.notifyListeners(evt)
         return evt
 
     def generate_location_events(self, location, pevent):

--- a/modules/sfp_template.py
+++ b/modules/sfp_template.py
@@ -245,12 +245,6 @@ class sfp_template(SpiderFootPlugin):
 
         return info
 
-    def emit(self, etype, data, pevent, notify=True):
-        evt = SpiderFootEvent(etype, data, self.__name__, pevent)
-        if notify:
-            self.notifyListeners(evt)
-        return evt
-
     # Handle events sent to this module
     def handleEvent(self, event):
         # The three most used fields in SpiderFootEvent are:

--- a/modules/sfp_zetalytics.py
+++ b/modules/sfp_zetalytics.py
@@ -62,10 +62,9 @@ class sfp_zetalytics(SpiderFootPlugin):
     def producedEvents(self):
         return ["INTERNET_NAME", "AFFILIATE_DOMAIN_NAME"]
 
-    def emit(self, etype, data, pevent, notify=True):
+    def emit(self, etype, data, pevent):
         evt = SpiderFootEvent(etype, data, self.__name__, pevent)
-        if notify:
-            self.notifyListeners(evt)
+        self.notifyListeners(evt)
         return evt
 
     def request(self, path, params):


### PR DESCRIPTION
In modules where it can remain (at least for now), remove the unused `notify` flag.