### PR TITLE
sflib: log debug messages in database

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -524,7 +524,7 @@ class SpiderFoot:
             else:
                 modName = mod.__name__
 
-        if self.dbh is None:
+        if self.dbh:
             self._dblog("DEBUG", message, modName)
 
         self.log.debug(f"{modName} : {message}")


### PR DESCRIPTION
Since ba0c2d18b7484e54e16c8fc65d7b2bcade33ffb2 debug messages were not logged in the database. This was a mistake. The same code pattern should have been used for the `debug` function as used for the `status` and `info` functions.
