### PR TITLE
Use Bootstrap form-group instead of input-group

### DIFF
--- a/dyn/opts.tmpl
+++ b/dyn/opts.tmpl
@@ -48,12 +48,12 @@
     % if not opt.startswith("__"):
     <tr><td>${opts['__globaloptdescs__'][opt]}</td><td style='vertical-align: middle'>
         % if type(opts[opt]) is int:
-        <div class='input-group'>
+        <div class='form-group'>
             <input id='${opt}' class='form-control' type=text value="${opts[opt]}">
         </div>
         % endif
         % if type(opts[opt]) is str:
-        <div class='input-group'>
+        <div class='form-group'>
             <input id='${opt}' style='width: 500px' class='form-control' type=text value="${opts[opt]}">
         </div>
         % endif
@@ -66,20 +66,20 @@
                 selfalse = "selected"  
                 seltrue = ""
         %>
-            <select id='${opt}'>
+            <select id='${opt}' class='form-control'>
                 <option value=1 ${seltrue}>True</option>
                 <option value=0 ${selfalse}>False</option>
             </select>
         % endif
         % if type(opts[opt]) is list and type(opts[opt][0]) is str:
             <% expandedopt = ','.join(opts[opt]) %>
-            <div class='input-group'>
+            <div class='form-group'>
                 <input id='${opt}' style='width: 500px' class='form-control' type=text value="${expandedopt}">
             </div>
         % endif
         % if type(opts[opt]) is list and type(opts[opt][0]) is int:
             <% expandedopt = ','.join(str(x) for x in opts[opt]) %>
-            <div class='input-group'>
+            <div class='form-group'>
                 <input id='${opt}' class='form-control' type=text value="${expandedopt}">
             </div>
         % endif
@@ -131,12 +131,12 @@
               </td>
               <td style='vertical-align: middle'>
             % if type(modopts[opt]) is int:
-                <div class='input-group'>
+                <div class='form-group'>
                     <input id='${mod}:${opt}' class='form-control' type=text value="${modopts[opt]}">
                 </div>
             % endif
             % if type(modopts[opt]) is str:
-                <div class='input-group'>
+                <div class='form-group'>
                     <input id='${mod}:${opt}' style='width: 500px' class='form-control' type=text value="${modopts[opt]}">
                 </div>
             % endif
@@ -149,20 +149,20 @@
                     selfalse = "selected"
                     seltrue = ""
             %>
-                <select id='${mod}:${opt}'>
+                <select id='${mod}:${opt}' class='form-control'>
                     <option value=1 ${seltrue}>True</option>
                     <option value=0 ${selfalse}>False</option>
                 </select>
             % endif
             % if type(modopts[opt]) is list and type(modopts[opt][0]) is str:
                 <% expandedopt = ','.join(modopts[opt]) %>
-                <div class='input-group'>
+                <div class='form-group'>
                     <input id='${mod}:${opt}' style='width: 500px' class='form-control' type=text value="${expandedopt}">
                 </div>
             % endif
             % if type(modopts[opt]) is list and type(modopts[opt][0]) is int:
                 <% expandedopt = ','.join(str(x) for x in modopts[opt]) %>
-                <div class='input-group'>
+                <div class='form-group'>
                     <input id='${mod}:${opt}' class='form-control' type=text value="${expandedopt}">
                 </div>
             % endif


### PR DESCRIPTION
Each option field only has one form control, so there is no need to use `input-group`. Instead, `form-group` can be used. This PR also adds Bootstrap styling to `select` elements