### PR TITLE
sfp_leakix: Added api-key support

### DIFF
--- a/modules/sfp_leakix.py
+++ b/modules/sfp_leakix.py
@@ -26,7 +26,7 @@ class sfp_leakix(SpiderFootPlugin):
         'categories': ["Leaks, Dumps and Breaches"],
         'dataSource': {
             'website': "https://leakix.net/",
-            'model': "FREE_NOAUTH_UNLIMITED",
+            'model': "FREE_AUTH_UNLIMITED",
             'references': [
                 "https://leakix.net/api-documentation"
             ],
@@ -40,6 +40,7 @@ class sfp_leakix(SpiderFootPlugin):
 
     # Default options
     opts = {
+        'api_key': "",
         'delay': 1,
     }
 
@@ -74,7 +75,8 @@ class sfp_leakix(SpiderFootPlugin):
     # https://leakix.net/api-documentation
     def queryHost(self, qry):
         headers = {
-            "Accept": "application/json"
+            "Accept": "application/json",
+            "api-key": self.opts["api_key"]
         }
         res = self.sf.fetchUrl(
             'https://leakix.net/host/' + qry,
@@ -130,6 +132,8 @@ class sfp_leakix(SpiderFootPlugin):
 
         self.results[eventData] = True
 
+        if self.opts['api_key'] == "":
+            self.sf.debug("You enabled sfp_leakix but did not set an API key, results are limited")
         self.sf.debug(f"Received event, {eventName}, from {srcModuleName}")
 
         if eventName in ["IP_ADDRESS"]:

--- a/modules/sfp_leakix.py
+++ b/modules/sfp_leakix.py
@@ -21,7 +21,7 @@ class sfp_leakix(SpiderFootPlugin):
     meta = {
         'name': "LeakIX",
         'summary': "Search LeakIX for host data leaks, open ports, software and geoip.",
-        'flags': [""],
+        'flags': ["apikey"],
         'useCases': ["Footprint", "Investigate", "Passive"],
         'categories': ["Leaks, Dumps and Breaches"],
         'dataSource': {
@@ -46,6 +46,7 @@ class sfp_leakix(SpiderFootPlugin):
 
     # Option descriptions
     optdescs = {
+        'api_key': "LeakIX API key",
         'delay': 'Delay between requests, in seconds.',
     }
 

--- a/modules/sfp_leakix.py
+++ b/modules/sfp_leakix.py
@@ -30,6 +30,13 @@ class sfp_leakix(SpiderFootPlugin):
             'references': [
                 "https://leakix.net/api-documentation"
             ],
+            'apiKeyInstructions': [
+                "Visit https://leakix.net/",
+                "Register a free account",
+                "Go to your 'Settings'",
+                "Click on 'API key'",
+                "Click on 'Reset key' to generate a new key"
+            ],
             'favIcon': "https://leakix.net/public/img/favicon.png",
             'logo': "https://leakix.net/public/img/logoleakix-v1.png",
             'description': "LeakIX provides insights into devices and servers that are compromised "


### PR DESCRIPTION
Hi, I'm adding this before tomorrow's deployment so it's ready just in case !

I'm not sure I should add `apikey` in `tags` since it won't be strictly required. The results will be limited in time if it's not present though.

Thanks for the orignal plugin @bcoles and the whole team for the tool :heart: 