### PR TITLE
sfwebui: Add support for CORS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ adblockparser>=0.7
 dnspython>=1.16.0
 exifread>=2.1.2
 CherryPy>=18.0
+cherrypy-cors>=1.6
 Mako>=1.0.4
 beautifulsoup4>=4.4.1
 lxml>=3.4.4


### PR DESCRIPTION
Does not support sending CORS request with credentials.

For now, a user must edit the source to whitelist an origin.

It does not make sense to wire this up to command line options. This can be resolved once SpiderFoot makes use of a config file for configuration options.
