### PR TITLE
docs: fix simple typo, proessing -> processing

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -439,7 +439,7 @@ class SpiderFootCli(cmd.Cmd):
 
         return ret
 
-    # Send the command output to the user, proessing the pipes
+    # Send the command output to the user, processing the pipes
     # that may have been used.
     def send_output(self, data, cmd, titles=None, total=True, raw=False):
         totalrec = 0


### PR DESCRIPTION
There is a small typo in sfcli.py.

Should read `processing` rather than `proessing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md