### PR TITLE
Upgrade pip to prevent issues with building Cryptography Python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENV PATH="/opt/venv/bin":$PATH
 COPY $REQUIREMENTS requirements.txt ./
 RUN ls
 RUN echo "$REQUIREMENTS"
+RUN pip3 install -U pip
 RUN pip3 install -r "$REQUIREMENTS"
 
 


### PR DESCRIPTION
With the current `Dockerfile`, attempting to build the image from it using `docker build -t spiderfoot:latest .` results in the following (truncated) error.

```
    ...
    copying src/cryptography/py.typed -> build/lib.linux-x86_64-3.6/cryptography
    running build_ext
    generating cffi module 'build/temp.linux-x86_64-3.6/_padding.c'
    creating build/temp.linux-x86_64-3.6
    generating cffi module 'build/temp.linux-x86_64-3.6/_openssl.c'
    running build_rust

        =============================DEBUG ASSISTANCE=============================
        If you are seeing a compilation error please try the following steps to
        successfully install cryptography:
        1) Upgrade to the latest pip and try again. This will fix errors for most
           users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
        2) Read https://cryptography.io/en/latest/installation.html for specific
           instructions for your platform.
        3) Check our frequently asked questions for more information:
           https://cryptography.io/en/latest/faq.html
        4) Ensure you have a recent Rust toolchain installed:
           https://cryptography.io/en/latest/installation.html#rust
        5) If you are experiencing issues with Rust for *this release only* you may
           set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
        =============================DEBUG ASSISTANCE=============================

    error: can't find Rust compiler

    If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.

    To update pip, run:

        pip install --upgrade pip

    and then retry package installation.

    If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.

    This package requires Rust >=1.41.0.

    ----------------------------------------
Command "/opt/venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-h6bsipmj/cryptography/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-d9q0n48s/install-record.txt --single-version-externally-managed --compile --install-headers /opt/venv/include/site/python3.6/cryptography" failed with error code 1 in /tmp/pip-install-h6bsipmj/cryptography/
You are using pip version 18.1, however version 21.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c pip3 install -r "$REQUIREMENTS"' returned a non-zero code: 1
```

As instructed by the error, the solution is to upgrade pip prior to installing any packages, the result of which can be seen below.

```
...
Step 22/23 : ENTRYPOINT ["/opt/venv/bin/python"]
 ---> Running in ad7108f87bd0
Removing intermediate container ad7108f87bd0
 ---> 5d578433f7f7
Step 23/23 : CMD ["sf.py", "-l", "0.0.0.0:5001"]
 ---> Running in dbd98859caa5
Removing intermediate container dbd98859caa5
 ---> f7c7dae8fe72
Successfully built f7c7dae8fe72
Successfully tagged spiderfoot:latest
```