### PR TITLE
Feature: Threaded Modules

### DIFF
--- a/sfscan.py
+++ b/sfscan.py
@@ -12,8 +12,12 @@
 import socket
 import sys
 import time
+import queue
+import threading
 import traceback
+from time import sleep
 from copy import deepcopy
+from collections import OrderedDict
 
 import dns.resolver
 
@@ -180,6 +184,9 @@ class SpiderFootScanner():
 
         self.__setStatus("INITIALIZING", time.time() * 1000, None)
 
+        # Used when module threading is enabled
+        self.eventQueue = None
+
         if start:
             self.__startScan()
 
@@ -222,13 +229,16 @@ class SpiderFootScanner():
         self.__status = status
         self.__dbh.scanInstanceSet(self.__scanId, started, ended, status)
 
-    def __startScan(self):
+    def __startScan(self, threaded=True):
         """Start running a scan."""
 
         aborted = False
 
         self.__setStatus("STARTING", time.time() * 1000, None)
         self.__sf.status(f"Scan [{self.__scanId}] initiated.")
+
+        if threaded:
+            self.eventQueue = queue.Queue()
 
         try:
             # moduleList = list of modules the user wants to run
@@ -276,22 +286,32 @@ class SpiderFootScanner():
                 if self.__config['__outputfilter']:
                     mod.setOutputFilter(self.__config['__outputfilter'])
 
+                # Register the target with the module
+                mod.setTarget(self.__target)
+
+                if threaded:
+                    # Set up the outgoing event queue
+                    mod.outgoingEventQueue = self.eventQueue
+                    mod.incomingEventQueue = queue.Queue()
+
                 self.__sf.status(modName + " module loaded.")
 
-            # Register listener modules and then start all modules sequentially
-            for module in list(self.__moduleInstances.values()):
-                # Register the target with the module
-                module.setTarget(self.__target)
+            # sort modules by priority
+            self.__moduleInstances = OrderedDict(sorted(self.__moduleInstances.items(), key=lambda m: m[-1]._priority))
 
-                for listenerModule in list(self.__moduleInstances.values()):
-                    # Careful not to register twice or you will get duplicate events
-                    if listenerModule in module._listenerModules:
-                        continue
-                    # Note the absence of a check for whether a module can register
-                    # to itself. That is intentional because some modules will
-                    # act on their own notifications (e.g. sfp_dns)!
-                    if listenerModule.watchedEvents() is not None:
-                        module.registerListener(listenerModule)
+            if not threaded:
+                # Register listener modules and then start all modules sequentially
+                for module in list(self.__moduleInstances.values()):
+                    
+                    for listenerModule in list(self.__moduleInstances.values()):
+                        # Careful not to register twice or you will get duplicate events
+                        if listenerModule in module._listenerModules:
+                            continue
+                        # Note the absence of a check for whether a module can register
+                        # to itself. That is intentional because some modules will
+                        # act on their own notifications (e.g. sfp_dns)!
+                        if listenerModule.watchedEvents() is not None:
+                            module.registerListener(listenerModule)
 
             # Now we are ready to roll..
             self.__setStatus("RUNNING")
@@ -302,9 +322,14 @@ class SpiderFootScanner():
             psMod.setTarget(self.__target)
             psMod.setDbh(self.__dbh)
             psMod.clearListeners()
-            for mod in list(self.__moduleInstances.values()):
-                if mod.watchedEvents() is not None:
-                    psMod.registerListener(mod)
+            if threaded:
+                psMod.outgoingEventQueue = self.eventQueue
+                psMod.incomingEventQueue = queue.Queue()
+            else:
+                for mod in list(self.__moduleInstances.values()):
+                    if mod.watchedEvents() is not None:
+                        psMod.registerListener(mod)
+
 
             # Create the "ROOT" event which un-triggered modules will link events to
             rootEvent = SpiderFootEvent("ROOT", self.__targetValue, "", None)
@@ -326,11 +351,15 @@ class SpiderFootScanner():
 
             # Check in case the user requested to stop the scan between modules
             # initializing
-            for module in list(self.__moduleInstances.values()):
-                if module.checkForStop():
+            for mod in list(self.__moduleInstances.values()):
+                if mod.checkForStop():
                     self.__setStatus('ABORTING')
                     aborted = True
                     break
+
+            # start threads
+            if threaded and not aborted:
+                self.waitForThreads()
 
             if aborted:
                 self.__sf.status(f"Scan [{self.__scanId}] aborted.")
@@ -347,3 +376,89 @@ class SpiderFootScanner():
             self.__setStatus("ERROR-FAILED", None, time.time() * 1000)
 
         self.__dbh.close()
+
+    def waitForThreads(self):
+
+        counter = 0
+
+        try:
+            if not self.eventQueue:
+                return
+
+            # start one thread for each module
+            for mod in self.__moduleInstances.values():
+                mod.start()
+
+            # watch for newly-generated events
+            while True:
+
+                # log status of threads every 100 iterations
+                log_status = counter % 100 == 0
+                counter += 1
+
+                try:
+                    sfEvent = self.eventQueue.get_nowait()
+                    self.__sf.debug(f"waitForThreads() got event, {sfEvent.eventType}, from eventQueue.")
+                except queue.Empty:
+                    # check if we're finished
+                    if self.threadsFinished(log_status):
+                        sleep(.1)
+                        # but are we really?
+                        if self.threadsFinished(log_status):
+                            break
+                    else:
+                        sleep(.01)
+                        continue
+
+                if not isinstance(sfEvent, SpiderFootEvent):
+                    raise TypeError(f"sfEvent is {type(sfEvent)}; expected SpiderFootEvent")
+
+                # for every module
+                for mod in self.__moduleInstances.values():
+                    # check if it's been aborted
+                    if mod._stopScanning:
+                        self.__sf.status(f"Scan [{self.__scanId}] aborted.")
+                        break
+                    # send the new event if applicable
+                    watchedEvents = mod.watchedEvents()
+                    if sfEvent.eventType in watchedEvents or "*" in watchedEvents:
+                        mod.incomingEventQueue.put(deepcopy(sfEvent))
+
+        except KeyboardInterrupt:
+            self.__sf.status(f"Scan [{self.__scanId}] aborted.")
+
+        finally:
+            # tell the modules to stop
+            for mod in self.__moduleInstances.values():
+                mod._stopScanning = True
+
+    def threadsFinished(self, log_status=False):
+
+        if not self.eventQueue:
+            return
+
+        modules_waiting = {m.__name__: m.incomingEventQueue.qsize() for m in self.__moduleInstances.values()}
+        modules_waiting = sorted(modules_waiting.items(), key=lambda x: x[-1], reverse=True)
+        modules_running = [m.__name__ for m in self.__moduleInstances.values() if m.running]
+        queues_empty = [qsize == 0 for m,qsize in modules_waiting]
+
+        if not modules_running and not queues_empty:
+            self.__sf.debug(f"Clearing queues for stalled/aborted modules.")
+            for mod in self.__moduleInstances.values():
+                try:
+                    while True:
+                        mod.incomingEventQueue.get_nowait()
+                except Exception:
+                    pass
+
+        if log_status and modules_running:
+            self.__sf.info(
+                f"Events queued: " + \
+                ", ".join([
+                    f"{mod}: {qsize:,}" for mod,qsize in modules_waiting[:5] if qsize > 0
+                ])
+            )
+
+        if self.eventQueue.empty() and all(queues_empty) and not modules_running:
+            return True
+        return False

--- a/sfscan.py
+++ b/sfscan.py
@@ -234,7 +234,6 @@ class SpiderFootScanner():
         Args:
             threaded (bool): whether to thread modules
         """
-
         aborted = False
 
         self.__setStatus("STARTING", time.time() * 1000, None)
@@ -380,7 +379,6 @@ class SpiderFootScanner():
         self.__dbh.close()
 
     def waitForThreads(self):
-
         counter = 0
 
         try:
@@ -437,7 +435,6 @@ class SpiderFootScanner():
                 mod._stopScanning = True
 
     def threadsFinished(self, log_status=False):
-
         if self.eventQueue is None:
             return True
 

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -346,7 +346,7 @@ class SpiderFootPlugin():
             self.setDbh(SpiderFootDb(self.opts))
 
             if not (self.incomingEventQueue and self.outgoingEventQueue):
-                self.log.error(f"Please set up queues before starting module as thread")
+                self.log.error("Please set up queues before starting module as thread")
                 return
 
             while not self.checkForStop():

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -2,7 +2,6 @@ import logging
 import threading
 import queue
 from time import sleep
-from spiderfoot import SpiderFootDb
 
 
 class SpiderFootPlugin():
@@ -343,6 +342,7 @@ class SpiderFootPlugin():
 
         try:
             # create new database handle since we're in our own thread
+            from spiderfoot import SpiderFootDb
             self.setDbh(SpiderFootDb(self.opts))
 
             if not (self.incomingEventQueue and self.outgoingEventQueue):

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -334,12 +334,10 @@ class SpiderFootPlugin():
         return
 
     def start(self):
-
         self.thread = threading.Thread(target=self.threadWorker)
         self.thread.start()
 
     def threadWorker(self):
-
         try:
             # create new database handle since we're in our own thread
             from spiderfoot import SpiderFootDb

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -1,4 +1,8 @@
 import logging
+import threading
+import queue
+from time import sleep
+from spiderfoot import SpiderFootDb
 
 
 class SpiderFootPlugin():
@@ -47,10 +51,18 @@ class SpiderFootPlugin():
     errorState = False
     # SOCKS proxy
     socksProxy = None
+    # Queue for incoming events
+    incomingEventQueue = None
+    # Queue for produced events
+    outgoingEventQueue = None
 
     def __init__(self):
         """Not really needed in most cases."""
-        pass
+
+        # Whether the module is currently executing
+        self.running = False
+        # Holds the thread object when module threading is enabled
+        self.thread = None
 
     def _updateSocket(self, socksProxy):
         """Hack to override module's use of socket, replacing it with
@@ -194,6 +206,7 @@ class SpiderFootPlugin():
         Raises:
             TypeError: sfEvent argument was invalid type
         """
+
         from spiderfoot import SpiderFootEvent
 
         if not isinstance(sfEvent, SpiderFootEvent):
@@ -239,26 +252,31 @@ class SpiderFootPlugin():
                     break
             prevEvent = prevEvent.sourceEvent
 
-        self._listenerModules.sort(key=lambda m: m._priority)
+        # output to queue if applicable
+        if self.outgoingEventQueue is not None:
+            self.outgoingEventQueue.put(sfEvent)
+        # otherwise, call other modules directly
+        else:
+            self._listenerModules.sort(key=lambda m: m._priority)
 
-        for listener in self._listenerModules:
-            if eventName not in listener.watchedEvents() and '*' not in listener.watchedEvents():
-                continue
+            for listener in self._listenerModules:
+                if eventName not in listener.watchedEvents() and '*' not in listener.watchedEvents():
+                    continue
 
-            if storeOnly and "__stor" not in listener.__module__:
-                continue
+                if storeOnly and "__stor" not in listener.__module__:
+                    continue
 
-            listener._currentEvent = sfEvent
+                listener._currentEvent = sfEvent
 
-            # Check if we've been asked to stop in the meantime, so that
-            # notifications stop triggering module activity.
-            if self.checkForStop():
-                return
+                # Check if we've been asked to stop in the meantime, so that
+                # notifications stop triggering module activity.
+                if self.checkForStop():
+                    return
 
-            try:
-                listener.handleEvent(sfEvent)
-            except Exception as e:
-                self.log.exception(f"Module ({listener.__module__}) encountered an error: {e}")
+                try:
+                    listener.handleEvent(sfEvent)
+                except Exception as e:
+                    self.log.exception(f"Module ({listener.__module__}) encountered an error: {e}")
 
     def checkForStop(self):
         """For modules to use to check for when they should give back control.
@@ -266,18 +284,21 @@ class SpiderFootPlugin():
         Returns:
             bool
         """
-        if not self.__scanId__:
+        if self.outgoingEventQueue and self.incomingEventQueue:
+            return self._stopScanning
+        else:
+            if not self.__scanId__:
+                return False
+
+            scanstatus = self.__sfdb__.scanInstanceGet(self.__scanId__)
+
+            if not scanstatus:
+                return False
+
+            if scanstatus[5] == "ABORT-REQUESTED":
+                return True
+
             return False
-
-        scanstatus = self.__sfdb__.scanInstanceGet(self.__scanId__)
-
-        if not scanstatus:
-            return False
-
-        if scanstatus[5] == "ABORT-REQUESTED":
-            return True
-
-        return False
 
     def watchedEvents(self):
         """What events is this module interested in for input. The format is a list
@@ -314,11 +335,39 @@ class SpiderFootPlugin():
         return
 
     def start(self):
-        """Kick off the work (for some modules nothing will happen here, but instead
-        the work will start from the handleEvent() method.
-        Will usually be overriden by the implementer.
-        """
 
-        return
+        self.thread = threading.Thread(target=self.threadWorker)
+        self.thread.start()
+
+    def threadWorker(self):
+
+        try:
+            # create new database handle since we're in our own thread
+            self.setDbh(SpiderFootDb(self.opts))
+
+            if not (self.incomingEventQueue and self.outgoingEventQueue):
+                self.log.error(f"Please set up queues before starting module as thread")
+                return
+
+            while not self.checkForStop():
+                try:
+                    sfEvent = self.incomingEventQueue.get_nowait()
+                    self.log.debug(f"{self.__name__}.threadWorker() got event, {sfEvent.eventType}, from incomingEventQueue.")
+                    self.running = True
+                    self.handleEvent(sfEvent)
+                    self.running = False
+                except queue.Empty:
+                    sleep(.3)
+                    continue
+        except KeyboardInterrupt:
+            self.log.warning(f"Interrupted module {self.__name__}.")
+            self._stopScanning = True
+        except Exception as e:
+            import traceback
+            self.log.error(f"Exception ({e.__class__.__name__}) in module {self.__name__}."
+                           + traceback.format_exc())
+            self.errorState = True
+        finally:
+            self.running = False
 
 # end of SpiderFootPlugin class


### PR DESCRIPTION
### This PR improves scan speeds by running each module in its own thread.

![threading_vs_nothreading](https://user-images.githubusercontent.com/20261699/120703441-4c9c3e80-c483-11eb-905f-7148a318f443.png)
* **No functionality was deleted, and there are no changes to individual modules.** A non-threaded scan can still be invoked by passing `threaded=False` to `SpiderFootScanner.__startScan()`
![threading_arg](https://user-images.githubusercontent.com/20261699/120703169-f5966980-c482-11eb-810e-84a99c48fc86.png)
* When threading is enabled, each module gets its own dedicated queue for "incoming" events, and shares an "outgoing" queue to `SpiderFootScanner`, which distributes new events across all the modules.
![diagram](https://user-images.githubusercontent.com/20261699/120703621-8a996280-c483-11eb-97ce-0d7228a95406.png)
* A status message periodically shows which modules have the most events queued. This makes it easy to identify slow-performing modules which are bottlenecking the scan.
```
[INFO] sfscan : Events queued: sfp_sslcert: 595, sfp_mnemonic: 569, sfp_pgp: 472, sfp_dnscommonsrv: 400, sfp_fringeproject: 357
```

