### PR TITLE
requirements_test: Add pytest-xdist==2.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - python -m pip install codecov -r requirements_test.txt
 
 script:
-  - python -m pytest --flake8 --durations=5 --cov-report term --cov=. .
+  - python -m pytest --flake8 -n auto --dist loadfile --durations=5 --cov-report term --cov=. .
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,5 +8,6 @@ pytest==6.0.2
 pytest-cov==2.10.1
 pytest-flake8==1.0.6
 pytest-mock==1.12.0
+pytest-xdist==2.2.1
 pycodestyle==2.6.0
 responses==0.12.0


### PR DESCRIPTION
I've been using `pytest-xdist` locally for over a year to significantly speed up tests.

I forget if there was a reason we weren't already using this in `requirements_test.txt` for CI. Let's see if the tests pass.
