### PR TITLE
Tests: test_sfp_reversewhois: skip invalid test

### DIFF
--- a/test/unit/modules/test_sfp_reversewhois.py
+++ b/test/unit/modules/test_sfp_reversewhois.py
@@ -1,4 +1,5 @@
 # test_sfp_reversewhois.py
+import pytest
 import unittest
 
 from modules.sfp_reversewhois import sfp_reversewhois
@@ -6,32 +7,11 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
+@pytest.mark.usefixtures
 class TestModulereversewhois(unittest.TestCase):
     """
     Test modules.sfp_reversewhois
     """
-
-    default_options = {
-        '_debug': False,  # Debug
-        '__logging': True,  # Logging in general
-        '__outputfilter': None,  # Event types to filter from modules' output
-        '_useragent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:62.0) Gecko/20100101 Firefox/62.0',  # User-Agent to use for HTTP requests
-        '_dnsserver': '',  # Override the default resolver
-        '_fetchtimeout': 5,  # number of seconds before giving up on a fetch
-        '_internettlds': 'https://publicsuffix.org/list/effective_tld_names.dat',
-        '_internettlds_cache': 72,
-        '_genericusers': "abuse,admin,billing,compliance,devnull,dns,ftp,hostmaster,inoc,ispfeedback,ispsupport,list-request,list,maildaemon,marketing,noc,no-reply,noreply,null,peering,peering-notify,peering-request,phish,phishing,postmaster,privacy,registrar,registry,root,routing-registry,rr,sales,security,spam,support,sysadmin,tech,undisclosed-recipients,unsubscribe,usenet,uucp,webmaster,www",
-        '__version__': '3.3',
-        '__database': 'spiderfoot.test.db',  # note: test database file
-        '__modules__': None,  # List of modules. Will be set after start-up.
-        '_socks1type': '',
-        '_socks2addr': '',
-        '_socks3port': '',
-        '_socks4user': '',
-        '_socks5pwd': '',
-        '_torctlport': 9051,
-        '__logstdout': False
-    }
 
     def test_opts(self):
         module = sfp_reversewhois()
@@ -54,6 +34,7 @@ class TestModulereversewhois(unittest.TestCase):
         module = sfp_reversewhois()
         self.assertIsInstance(module.producedEvents(), list)
 
+    @unittest.skip("todo")
     def test_handleEvent(self):
         """
         Test handleEvent(self, event)
@@ -63,8 +44,8 @@ class TestModulereversewhois(unittest.TestCase):
         module = sfp_reversewhois()
         module.setup(sf, dict())
 
-        target_value = 'example target value'
-        target_type = 'IP_ADDRESS'
+        target_value = 'spiderfoot.net'
+        target_type = 'DOMAIN_NAME'
         target = SpiderFootTarget(target_value, target_type)
         module.setTarget(target)
 


### PR DESCRIPTION
This test does not make sense and should be skipped.
