### PR TITLE
DB: Add 'LEI' (Legal Entity Identifier) data type

### DIFF
--- a/spiderfoot/db.py
+++ b/spiderfoot/db.py
@@ -164,6 +164,7 @@ class SpiderFootDb:
         ['INTERNET_NAME_UNRESOLVED', 'Internet Name - Unresolved', 0, 'ENTITY'],
         ['IP_ADDRESS', 'IP Address', 0, 'ENTITY'],
         ['IPV6_ADDRESS', 'IPv6 Address', 0, 'ENTITY'],
+        ['LEI', 'Legal Entity Identifier', 0, 'ENTITY'],
         ['JOB_TITLE', 'Job Title', 0, 'DESCRIPTOR'],
         ['LINKED_URL_INTERNAL', 'Linked URL - Internal', 0, 'SUBENTITY'],
         ['LINKED_URL_EXTERNAL', 'Linked URL - External', 0, 'SUBENTITY'],


### PR DESCRIPTION
Used for a work-in-progress module. LEI (Legal Entity Identifier) allows uniquely identifying organisations which assists with matching and normalisation of companies.
