### PR TITLE
requirements: Bump pytest version from 6.0.2 to 6.2.4

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ dlint==0.10.3
 flake8==3.8.3
 flake8-bugbear==20.1.4
 flake8-return==1.1.2
-pytest==6.0.2
+pytest==6.2.4
 pytest-cov==2.10.1
 pytest-flake8==1.0.6
 pytest-mock==1.12.0


### PR DESCRIPTION
Version 6.2.4 fixes some bugs and security issues.
