### PR TITLE
SpiderFootHelpers: rename SpiderFootHelpers.targetType to SpiderFootHelpers.targetTypeFromString

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -283,7 +283,7 @@ def start_scan(sfConfig, sfModules, args):
         target = f"\"{target}\""
     if "." not in target and not target.startswith("+") and '"' not in target:
         target = f"\"{target}\""
-    targetType = SpiderFootHelpers.targetType(target)
+    targetType = SpiderFootHelpers.targetTypeFromString(target)
 
     if not targetType:
         log.error(f"Could not determine target type. Invalid target: {target}")

--- a/sfwebui.py
+++ b/sfwebui.py
@@ -547,12 +547,12 @@ class SpiderFootWebUi:
         if "sfp__stor_stdout" in modlist:
             modlist.remove("sfp__stor_stdout")
 
-        targetType = SpiderFootHelpers.targetType(scantarget)
+        targetType = SpiderFootHelpers.targetTypeFromString(scantarget)
         if not targetType:
             # It must then be a name, as a re-run scan should always have a clean
             # target. Put quotes around the target value and try to determine the
             # target type again.
-            targetType = SpiderFootHelpers.targetType(f'"{scantarget}"')
+            targetType = SpiderFootHelpers.targetTypeFromString(f'"{scantarget}"')
 
         if targetType not in ["HUMAN_NAME", "BITCOIN_ADDRESS"]:
             scantarget = scantarget.lower()
@@ -608,7 +608,7 @@ class SpiderFootWebUi:
             if "sfp__stor_stdout" in modlist:
                 modlist.remove("sfp__stor_stdout")
 
-            targetType = SpiderFootHelpers.targetType(scantarget)
+            targetType = SpiderFootHelpers.targetTypeFromString(scantarget)
             if targetType is None:
                 # Should never be triggered for a re-run scan..
                 return self.error("Invalid target type. Could not recognize it as a target SpiderFoot supports.")
@@ -673,7 +673,7 @@ class SpiderFootWebUi:
         if scanname == "" or scantarget == "" or len(scanconfig) == 0:
             return self.error("Something went wrong internally.")
 
-        targetType = SpiderFootHelpers.targetType(scantarget)
+        targetType = SpiderFootHelpers.targetTypeFromString(scantarget)
         if targetType is None:
             # It must be a name, so wrap quotes around it
             scantarget = "&quot;" + scantarget + "&quot;"
@@ -1118,7 +1118,7 @@ class SpiderFootWebUi:
 
             return self.error("Invalid request: no modules specified for scan.")
 
-        targetType = SpiderFootHelpers.targetType(scantarget)
+        targetType = SpiderFootHelpers.targetTypeFromString(scantarget)
         if targetType is None:
             if cherrypy.request.headers.get('Accept') and 'application/json' in cherrypy.request.headers.get('Accept'):
                 cherrypy.response.headers['Content-Type'] = "application/json; charset=utf-8"

--- a/spiderfoot/helpers.py
+++ b/spiderfoot/helpers.py
@@ -9,7 +9,7 @@ class SpiderFootHelpers():
     """SpiderFoot helper functions."""
 
     @staticmethod
-    def targetType(target):
+    def targetTypeFromString(target):
         """Return the scan target seed data type for the specified scan target input.
 
         Args:

--- a/test/unit/test_spiderfoothelpers.py
+++ b/test/unit/test_spiderfoothelpers.py
@@ -15,38 +15,38 @@ class TestSpiderFootHelpers(unittest.TestCase):
         """
         Test targetType(target)
         """
-        target_type = SpiderFootHelpers.targetType("0.0.0.0")
+        target_type = SpiderFootHelpers.targetTypeFromString("0.0.0.0")
         self.assertEqual('IP_ADDRESS', target_type)
-        target_type = SpiderFootHelpers.targetType("noreply@spiderfoot.net")
+        target_type = SpiderFootHelpers.targetTypeFromString("noreply@spiderfoot.net")
         self.assertEqual('EMAILADDR', target_type)
-        target_type = SpiderFootHelpers.targetType("0.0.0.0/0")
+        target_type = SpiderFootHelpers.targetTypeFromString("0.0.0.0/0")
         self.assertEqual('NETBLOCK_OWNER', target_type)
-        target_type = SpiderFootHelpers.targetType("+1234567890")
+        target_type = SpiderFootHelpers.targetTypeFromString("+1234567890")
         self.assertEqual('PHONE_NUMBER', target_type)
-        target_type = SpiderFootHelpers.targetType('"Human Name"')
+        target_type = SpiderFootHelpers.targetTypeFromString('"Human Name"')
         self.assertEqual('HUMAN_NAME', target_type)
-        target_type = SpiderFootHelpers.targetType('"abc123"')
+        target_type = SpiderFootHelpers.targetTypeFromString('"abc123"')
         self.assertEqual('USERNAME', target_type)
-        target_type = SpiderFootHelpers.targetType("1234567890")
+        target_type = SpiderFootHelpers.targetTypeFromString("1234567890")
         self.assertEqual('BGP_AS_OWNER', target_type)
-        target_type = SpiderFootHelpers.targetType("::1")
+        target_type = SpiderFootHelpers.targetTypeFromString("::1")
         self.assertEqual('IPV6_ADDRESS', target_type)
-        target_type = SpiderFootHelpers.targetType("spiderfoot.net")
+        target_type = SpiderFootHelpers.targetTypeFromString("spiderfoot.net")
         self.assertEqual('INTERNET_NAME', target_type)
-        target_type = SpiderFootHelpers.targetType("1HesYJSP1QqcyPEjnQ9vzBL1wujruNGe7R")
+        target_type = SpiderFootHelpers.targetTypeFromString("1HesYJSP1QqcyPEjnQ9vzBL1wujruNGe7R")
         self.assertEqual('BITCOIN_ADDRESS', target_type)
 
     def test_target_type_invalid_seed_should_return_none(self):
         """
         Test targetType(target)
         """
-        target_type = SpiderFootHelpers.targetType(None)
+        target_type = SpiderFootHelpers.targetTypeFromString(None)
         self.assertEqual(None, target_type)
 
-        target_type = SpiderFootHelpers.targetType("")
+        target_type = SpiderFootHelpers.targetTypeFromString("")
         self.assertEqual(None, target_type)
 
-        target_type = SpiderFootHelpers.targetType('""')
+        target_type = SpiderFootHelpers.targetTypeFromString('""')
         self.assertEqual(None, target_type)
 
     def test_buildGraphData_should_return_a_set(self):


### PR DESCRIPTION
This was too confusing as we have various accessors and paramaters elsewhere called targetType.
