### PR TITLE
sfp_dnsresolve: Remove stale TODO comment

### DIFF
--- a/modules/sfp_dnsresolve.py
+++ b/modules/sfp_dnsresolve.py
@@ -238,7 +238,6 @@ class sfp_dnsresolve(SpiderFootPlugin):
                 addrs = self.sf.resolveIP(ipaddr)
                 if addrs:
                     self.sf.debug(f"Found a reversed hostname from {ipaddr} ({addrs})")
-                    # TODO: review why addr is not used in this loop. should `ipaddr` instead be `addr` ?
                     for addr in addrs:
                         # Generate an event for the IP, then
                         # let the handling by this module take


### PR DESCRIPTION
This was resolved in 89b7633608c909013b49ee32c987ce935a6bd0fc but the `TODO` comment was not removed.
