### PR TITLE
Resolve networkx import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ secure>=0.3.0,<0.4.0
 pyOpenSSL>=17.5.0
 python-docx>=0.8.10
 python-pptx>=0.6.18
-networkx>=2.5
+networkx>=2.6.2
 cryptography>=3.3.2
 publicsuffixlist>=0.7.3

--- a/spiderfoot/helpers.py
+++ b/spiderfoot/helpers.py
@@ -2,7 +2,7 @@ import json
 import random
 import re
 import uuid
-from networkx import nx
+import networkx as nx
 from networkx.readwrite.gexf import GEXFWriter
 
 


### PR DESCRIPTION
The following error was introduced recently, seemingly the result of a change in the `networkx` library. It is resolved by modifying the import statement to `import networkx as nx`.
```
spiderfoot    | Traceback (most recent call last):
spiderfoot    |   File "sf.py", line 31, in <module>
spiderfoot    |     from sfscan import SpiderFootScanner
spiderfoot    |   File "/home/spiderfoot/sfscan.py", line 24, in <module>
spiderfoot    |     from spiderfoot import SpiderFootDb, SpiderFootEvent, SpiderFootPlugin, SpiderFootTarget, SpiderFootHelpers
spiderfoot    |   File "/home/spiderfoot/spiderfoot/__init__.py", line 5, in <module>
spiderfoot    |     from .helpers import SpiderFootHelpers
spiderfoot    |   File "/home/spiderfoot/spiderfoot/helpers.py", line 5, in <module>
spiderfoot    |     from networkx import nx
spiderfoot    | ImportError: cannot import name 'nx' from 'networkx' (/opt/venv/lib/python3.8/site-packages/networkx/__init__.py)
```