### PR TITLE
sfp_searchcode: Start from page 0 not page 1

### DIFF
--- a/modules/sfp_searchcode.py
+++ b/modules/sfp_searchcode.py
@@ -128,8 +128,8 @@ class sfp_searchcode(SpiderFootPlugin):
         self.results[eventData] = True
 
         max_pages = int(self.opts['max_pages'])
-        page = 1
-        while page <= max_pages:
+        page = 0
+        while page < max_pages:
             if self.checkForStop():
                 return
 
@@ -167,11 +167,12 @@ class sfp_searchcode(SpiderFootPlugin):
 
             links = set()
             for result in results:
-                if 'lines' in result:
-                    for line in result['lines']:
-                        links.update(self.sf.extractUrls(result['lines'][line]))
+                lines = result.get('lines')
+                if lines:
+                    for line in lines:
+                        links.update(self.sf.extractUrls(lines[line]))
 
-            for link in list(links):
+            for link in links:
                 if link in self.results:
                     continue
 


### PR DESCRIPTION
I'm not sure if the API previously started at page one or if this is a bug which has always existed in this module.
