### PR TITLE
DNSDumpster Fix

### DIFF
--- a/modules/sfp_dnsdumpster.py
+++ b/modules/sfp_dnsdumpster.py
@@ -91,7 +91,8 @@ class sfp_dnsdumpster(SpiderFootPlugin):
             },
             postData={
                 "csrfmiddlewaretoken": csrfmiddlewaretoken,
-                "targetip": str(domain).lower()
+                "targetip": str(domain).lower(),
+                "user": "free"
             },
             headers={
                 "origin": "https://dnsdumpster.com",


### PR DESCRIPTION
They updated the the page to require an extra POST parameter: `user=free`.
![image](https://user-images.githubusercontent.com/20261699/128771463-0dda201f-ed0c-46f3-b326-2f22bed57c1e.png)
