### PR TITLE
sfwebui: do not show api key instructions for modules with no instructions

### DIFF
--- a/spiderfoot/templates/opts.tmpl
+++ b/spiderfoot/templates/opts.tmpl
@@ -134,18 +134,17 @@
             <tr>
               <td>${optdescs.get(opt) or "No description available."}
                 % if "api_key" in opt:
-                    <%
-                        import re
-                        if apiKeyInstructions:
-                            n = 0
+                    % if apiKeyInstructions:
+                        <%
+                            import re
                             instructions = ""
                             for step in apiKeyInstructions:
-                                n += 1
                                 if "https://" in step or "http://" in step:
                                     step = re.sub(r'.*(https?://.[^ ]+).*', '<a target=_new href=\'\\1\'>\\1</a>', step)
-                                instructions += str(n) + ". " + step + "<br>"
-                    %>
-                    &nbsp;&nbsp;<a href='#' data-html="true" data-toggle="popover" data-trigger="focus" title="Instructions" data-content="${instructions}"><i class="glyphicon glyphicon-question-sign"></i></a>
+                                instructions += f"<li>{step}</li>"
+                        %>
+                        &nbsp;&nbsp;<a href='#' data-html="true" data-toggle="popover" data-trigger="focus" title="Instructions" data-content="<ol>${instructions}</ol>"><i class="glyphicon glyphicon-question-sign"></i></a>
+                    % endif
                 % endif
               </td>
               <td style='vertical-align: middle'>


### PR DESCRIPTION
Adds changes to `opts.tmpl` template missed in #1264.
