### PR TITLE
sfp_blocklistde: Set correct timeout argument for self.sf.fetchUrl()

### DIFF
--- a/modules/sfp_blocklistde.py
+++ b/modules/sfp_blocklistde.py
@@ -114,7 +114,7 @@ class sfp_blocklistde(SpiderFootPlugin):
 
         res = self.sf.fetchUrl(
             "https://lists.blocklist.de/lists/all.txt",
-            self.opts['_fetchtimeout'],
+            timeout=self.opts['_fetchtimeout'],
             useragent=self.opts['_useragent'],
         )
 


### PR DESCRIPTION
Fix bug introduced in #1279.
