### PR TITLE
Tests: Add a few simple test wrapper shell scripts

### DIFF
--- a/test/acceptance/run
+++ b/test/acceptance/run
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run acceptance tests
+#
+# Requires robotframework:
+#   cd test/acceptance; pip3 install -r requirements.txt
+
+time robot --outputdir results scan.robot

--- a/test/bandit
+++ b/test/bandit
@@ -1,2 +1,7 @@
 #!/bin/sh
-python3 -m bandit *.py modules/*.py
+# Run bandit static analysis checks
+#
+# Must be run from SpiderFoot root directory; ie:
+# ./test/bandit
+
+python3 -m bandit *.py spiderfoot/* modules/*.py

--- a/test/run
+++ b/test/run
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Run unit and integration tests.
+# These same tests are run on all pull requests automatically.
+#
+# Must be run from SpiderFoot root directory; ie:
+# ./test/run
+
+time python3 -m pytest -n auto --flake8 --dist loadfile --durations=5 --cov-report term --cov=. .

--- a/test/update-requirements
+++ b/test/update-requirements
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Update and lock all pip packages to latest version.
+#
+# Must be run from SpiderFoot root directory; ie:
+# ./test/update-requirements
+#
+# Requires lock-requirements:
+#   pip3 install lock-requirements
+
+lock requirements.txt
+git diff requirements.txt
+
+lock test/requirements.txt
+git diff test/requirements.txt
+
+# python3 -m safety check -r test/requirements.txt


### PR DESCRIPTION
Adds a few scripts I use locally. I use these often enough for testing that they may be useful to keep in the repo.

`test/run` is a simple wrapper for the unit and integration tests. When testing local changes, if these tests complete successfully, then the tests should also pass upon pull request when run as part of the GitHub tests workflow.

`test/acceptance/run` is a simple wrapper to run the acceptance tests.

`test/update-requirements` may be useful to update dependencies before a release, to ensure SpiderFoot works with the latest versions

`test/bandit` already existed in tree, but needed to be updated to account for the new `./spiderfoot` directory. This script wraps `bandit` to find security issues with static analysis. For now, we're using this separately rather than as part of the test suite with `flake8`.

Eventually these should be replaced with `tox`.
