### PR TITLE
sfp_phishtank: Fix blacklist host check

### DIFF
--- a/modules/sfp_phishtank.py
+++ b/modules/sfp_phishtank.py
@@ -82,9 +82,9 @@ class sfp_phishtank(SpiderFootPlugin):
                 continue
             if target.lower() in item[1]:
                 self.sf.debug(f"Host name {target} found in phishtank.com blacklist.")
-            return item[0]
+                return item[0]
 
-        return
+        return None
 
     def retrieveBlacklist(self):
         blacklist = self.sf.cacheGet('phishtank', 24)


### PR DESCRIPTION
This module was erroneously returning a match regardless of whether the target was in the blacklist resulting in false positives.
