### PR TITLE
spiderfoot: event: Remove risk/visibility/confidence args from constructor

### DIFF
--- a/spiderfoot/event.py
+++ b/spiderfoot/event.py
@@ -35,7 +35,7 @@ class SpiderFootEvent():
     _actualSource = None
     __id = None
 
-    def __init__(self, eventType: str, data: str, module: str, sourceEvent: 'SpiderFootEvent', confidence: int = 100, visibility: int = 100, risk: int = 0) -> None:
+    def __init__(self, eventType: str, data: str, module: str, sourceEvent: 'SpiderFootEvent') -> None:
         """Initialize SpiderFoot event object.
 
         Args:
@@ -43,17 +43,14 @@ class SpiderFootEvent():
             data (str): Event data, e.g. a URL, port number, webpage content, etc.
             module (str): Module from which the event originated
             sourceEvent (SpiderFootEvent): SpiderFootEvent event that triggered this event
-            confidence (int): How sure are we of this data's validity, 0-100
-            visibility (int): How 'visible' was this data, 0-100
-            risk (int): How much risk does this data represent, 0-100
         """
         self._generated = time.time()
         self.data = data
         self.eventType = eventType
         self.module = module
-        self.confidence = confidence
-        self.visibility = visibility
-        self.risk = risk
+        self.confidence = 100
+        self.visibility = 100
+        self.risk = 0
         self.sourceEvent = sourceEvent
         self.__id = f"{self.eventType}{self.generated}{self.module}{random.SystemRandom().randint(0, 99999999)}"
 

--- a/test/unit/spiderfoot/test_spiderfootevent.py
+++ b/test/unit/spiderfoot/test_spiderfootevent.py
@@ -11,7 +11,7 @@ class TestSpiderFootEvent(unittest.TestCase):
 
     def test_init_root_event_should_create_event(self):
         """
-        Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
+        Test __init__(self, eventType, data, module, sourceEvent)
         """
         event_data = 'example event data'
         module = 'example module'
@@ -23,7 +23,7 @@ class TestSpiderFootEvent(unittest.TestCase):
 
     def test_init_nonroot_event_with_root_sourceEvent_should_create_event(self):
         """
-        Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
+        Test __init__(self, eventType, data, module, sourceEvent)
         """
         event_type = 'ROOT'
         event_data = 'example event data'
@@ -39,7 +39,7 @@ class TestSpiderFootEvent(unittest.TestCase):
 
     def test_init_argument_eventType_of_invalid_type_should_raise_TypeError(self):
         """
-        Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
+        Test __init__(self, eventType, data, module, sourceEvent)
         """
         event_type = 'ROOT'
         event_data = 'example event data'
@@ -70,7 +70,7 @@ class TestSpiderFootEvent(unittest.TestCase):
 
     def test_init_argument_data_of_invalid_type_should_raise_TypeError(self):
         """
-        Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
+        Test __init__(self, eventType, data, module, sourceEvent)
         """
         event_type = 'ROOT'
         module = ''
@@ -98,7 +98,7 @@ class TestSpiderFootEvent(unittest.TestCase):
 
     def test_init_argument_module_of_invalid_type_should_raise_TypeError(self):
         """
-        Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
+        Test __init__(self, eventType, data, module, sourceEvent)
         """
         event_type = 'ROOT'
         event_data = 'example event data'
@@ -128,7 +128,7 @@ class TestSpiderFootEvent(unittest.TestCase):
 
     def test_init_argument_sourceEvent_of_invalid_type_should_raise_TypeError(self):
         """
-        Test __init__(self, eventType, data, module, sourceEvent, confidence=100, visibility=100, risk=0)
+        Test __init__(self, eventType, data, module, sourceEvent)
         """
         event_type = 'ROOT'
         event_data = 'example event data'
@@ -152,7 +152,8 @@ class TestSpiderFootEvent(unittest.TestCase):
         for invalid_type in invalid_types:
             with self.subTest(invalid_type=invalid_type):
                 with self.assertRaises(TypeError):
-                    SpiderFootEvent(event_type, event_data, module, source_event, confidence=invalid_type)
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event)
+                    evt.confidence = invalid_type
 
     def test_init_argument_confidence_invalid_value_should_raise_ValueError(self):
         event_type = 'ROOT'
@@ -164,7 +165,8 @@ class TestSpiderFootEvent(unittest.TestCase):
         for invalid_value in invalid_values:
             with self.subTest(invalid_value=invalid_value):
                 with self.assertRaises(ValueError):
-                    SpiderFootEvent(event_type, event_data, module, source_event, confidence=invalid_value)
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event)
+                    evt.confidence = invalid_value
 
     def test_init_argument_visibility_of_invalid_type_should_raise_TypeError(self):
         event_type = 'ROOT'
@@ -176,7 +178,8 @@ class TestSpiderFootEvent(unittest.TestCase):
         for invalid_type in invalid_types:
             with self.subTest(invalid_type=invalid_type):
                 with self.assertRaises(TypeError):
-                    SpiderFootEvent(event_type, event_data, module, source_event, visibility=invalid_type)
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event)
+                    evt.visibility = invalid_type
 
     def test_init_argument_visibility_invalid_value_should_raise_ValueError(self):
         event_type = 'ROOT'
@@ -188,7 +191,8 @@ class TestSpiderFootEvent(unittest.TestCase):
         for invalid_value in invalid_values:
             with self.subTest(invalid_value=invalid_value):
                 with self.assertRaises(ValueError):
-                    SpiderFootEvent(event_type, event_data, module, source_event, visibility=invalid_value)
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event)
+                    evt.visibility = invalid_value
 
     def test_init_argument_risk_of_invalid_type_should_raise_TypeError(self):
         event_type = 'ROOT'
@@ -200,7 +204,8 @@ class TestSpiderFootEvent(unittest.TestCase):
         for invalid_type in invalid_types:
             with self.subTest(invalid_type=invalid_type):
                 with self.assertRaises(TypeError):
-                    SpiderFootEvent(event_type, event_data, module, source_event, risk=invalid_type)
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event)
+                    evt.risk = invalid_type
 
     def test_init_argument_risk_invalid_value_should_raise_ValueError(self):
         event_type = 'ROOT'
@@ -212,7 +217,8 @@ class TestSpiderFootEvent(unittest.TestCase):
         for invalid_value in invalid_values:
             with self.subTest(invalid_value=invalid_value):
                 with self.assertRaises(ValueError):
-                    SpiderFootEvent(event_type, event_data, module, source_event, risk=invalid_value)
+                    evt = SpiderFootEvent(event_type, event_data, module, source_event)
+                    evt.risk = invalid_value
 
     def test_confidence_attribute_should_return_confidence_as_integer(self):
         event_type = 'ROOT'
@@ -220,7 +226,9 @@ class TestSpiderFootEvent(unittest.TestCase):
         module = ''
         source_event = ''
         confidence = 100
-        evt = SpiderFootEvent(event_type, event_data, module, source_event, confidence=confidence)
+
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+        evt.confidence = confidence
 
         self.assertEqual(confidence, evt.confidence)
 
@@ -243,7 +251,9 @@ class TestSpiderFootEvent(unittest.TestCase):
         module = ''
         source_event = ''
         visibility = 100
-        evt = SpiderFootEvent(event_type, event_data, module, source_event, visibility=visibility)
+
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+        evt.visibility = visibility
 
         self.assertEqual(visibility, evt.visibility)
 
@@ -266,7 +276,9 @@ class TestSpiderFootEvent(unittest.TestCase):
         module = ''
         source_event = ''
         risk = 100
-        evt = SpiderFootEvent(event_type, event_data, module, source_event, risk=risk)
+
+        evt = SpiderFootEvent(event_type, event_data, module, source_event)
+        evt.risk = risk
 
         self.assertEqual(risk, evt.risk)
 


### PR DESCRIPTION
We've never used these. They are always set to default.

Other properties that we do actually use, like `actualSource`, are set directly. ie, `event.actualySource = '...'`. We can do the same with risk/visibility/confidence if necessary.
