### PR TITLE
Add Module Shutdown Hook

### DIFF
--- a/sfscan.py
+++ b/sfscan.py
@@ -473,16 +473,15 @@ class SpiderFootScanner():
                         if self.threadsFinished(log_status):
                             if modulesFinished:
                                 break
-                            else:
-                                # Trigger module.finished()
-                                for mod in self.__moduleInstances.values():
-                                    mod.incomingEventQueue.put('FINISHED')
-                                sleep(.1)
-                                while not self.threadsFinished(log_status):
-                                    log_status = counter % 100 == 0
-                                    counter += 1
-                                    sleep(.01)
-                                modulesFinished = True
+                            # Trigger module.finished()
+                            for mod in self.__moduleInstances.values():
+                                mod.incomingEventQueue.put('FINISHED')
+                            sleep(.1)
+                            while not self.threadsFinished(log_status):
+                                log_status = counter % 100 == 0
+                                counter += 1
+                                sleep(.01)
+                            modulesFinished = True
 
                     else:
                         # save on CPU

--- a/sfscan.py
+++ b/sfscan.py
@@ -453,6 +453,7 @@ class SpiderFootScanner():
             # start one thread for each module
             for mod in self.__moduleInstances.values():
                 mod.start()
+            modulesFinished = False
 
             # watch for newly-generated events
             while True:

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -387,9 +387,13 @@ class SpiderFootPlugin():
             while not self.checkForStop():
                 try:
                     sfEvent = self.incomingEventQueue.get_nowait()
-                    self.sf.debug(f"{self.__name__}.threadWorker() got event, {sfEvent.eventType}, from incomingEventQueue.")
                     self.running = True
-                    self.handleEvent(sfEvent)
+                    if sfEvent == 'FINISHED':
+                        self.sf.debug(f"{self.__name__}.threadWorker() got \"FINISHED\" from incomingEventQueue.")
+                        self.finish()
+                    else:
+                        self.sf.debug(f"{self.__name__}.threadWorker() got event, {sfEvent.eventType}, from incomingEventQueue.")
+                        self.handleEvent(sfEvent)
                     self.running = False
                 except queue.Empty:
                     sleep(.3)

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -366,6 +366,13 @@ class SpiderFootPlugin():
         self.thread = threading.Thread(target=self.threadWorker)
         self.thread.start()
 
+    def finish(self):
+        """Perform final/cleanup functions before module exits
+        Overridden by the implementer
+        """
+
+        return
+
     def threadWorker(self):
         try:
             # create new database handle since we're in our own thread


### PR DESCRIPTION
This PR adds a shutdown hook so that (future) modules that support concurrent/batch processing of events can wrap up their operations cleanly.