### PR TITLE
SpiderFootHelpers: targetTypeFromString: Add NETBLOCKV6_OWNER target type

### DIFF
--- a/spiderfoot/helpers.py
+++ b/spiderfoot/helpers.py
@@ -78,6 +78,7 @@ class SpiderFootHelpers():
             {r"^\".+\"$": "USERNAME"},
             {r"^[0-9]+$": "BGP_AS_OWNER"},
             {r"^[0-9a-f:]+$": "IPV6_ADDRESS"},
+            {r"^[0-9a-f:]+::/[0-9]+$": "NETBLOCKV6_OWNER"},
             {r"^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)+([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$": "INTERNET_NAME"},
             {r"^([13][a-km-zA-HJ-NP-Z1-9]{25,34})$": "BITCOIN_ADDRESS"}
         ]


### PR DESCRIPTION
Updates the `SpiderFootHelpers.targetTypeFromString` function to support IPv6 netblocks as input for new scans.

This isn't advertised anywhere in the user interface yet. Many modules which accept `NETBLOCK*` events still need to be reviewed for IPv6 handling.

I need this change locally for testing and it needed to be made eventually anyway.
