### PR TITLE
Added spiderfoot-integrated thread pool

### DIFF
--- a/sfscan.py
+++ b/sfscan.py
@@ -538,7 +538,6 @@ class SpiderFootScanner():
             if modules_running:
                 self.__sf.debug(f"Modules running: {', '.join(modules_running)}")
 
-
         if all(queues_empty) and not modules_running:
             return True
         return False

--- a/sfscan.py
+++ b/sfscan.py
@@ -530,10 +530,14 @@ class SpiderFootScanner():
                 except Exception:
                     pass
 
-        if log_status and modules_running:
+        if log_status:
             events_queued = ", ".join([f"{mod}: {qsize:,}" for mod, qsize in modules_waiting[:5] if qsize > 0])
-            if events_queued:
-                self.__sf.debug(f"Events queued: {events_queued}")
+            if not events_queued:
+                events_queued = 'None'
+            self.__sf.debug(f"Events queued: {events_queued}")
+            if modules_running:
+                self.__sf.debug(f"Modules running: {', '.join(modules_running)}")
+
 
         if all(queues_empty) and not modules_running:
             return True

--- a/sfscan.py
+++ b/sfscan.py
@@ -289,7 +289,7 @@ class SpiderFootScanner():
                 mod = getattr(module, modName)()
                 mod.__name__ = modName
             except Exception as e:
-                self.__sf.error(f"Module {modName} initialization failed: {e}")
+                self.__sf.error(f"Module {modName} initialization failed: {traceback.format_exc()}")
                 continue
 
             # Set up the module options, scan ID, database handle and listeners
@@ -305,7 +305,8 @@ class SpiderFootScanner():
                 mod.setDbh(self.__dbh)
                 mod.setScanId(self.__scanId)
             except Exception as e:
-                self.__sf.error(f"Module {modName} initialization failed: {e}")
+                self.__sf.error(f"Module {modName} initialization failed: {traceback.format_exc()}")
+                mod.errorState = True
                 continue
 
             # Override the module's local socket module to be the SOCKS one.

--- a/sfscan.py
+++ b/sfscan.py
@@ -288,7 +288,7 @@ class SpiderFootScanner():
             try:
                 mod = getattr(module, modName)()
                 mod.__name__ = modName
-            except Exception as e:
+            except Exception:
                 self.__sf.error(f"Module {modName} initialization failed: {traceback.format_exc()}")
                 continue
 
@@ -304,7 +304,7 @@ class SpiderFootScanner():
                 mod.setup(self.__sf, self.__modconfig[modName])
                 mod.setDbh(self.__dbh)
                 mod.setScanId(self.__scanId)
-            except Exception as e:
+            except Exception:
                 self.__sf.error(f"Module {modName} initialization failed: {traceback.format_exc()}")
                 mod.errorState = True
                 continue

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -63,8 +63,8 @@ class SpiderFootPlugin():
     def __init__(self):
         """Not really needed in most cases."""
 
-        # Whether the module is currently executing
-        self.running = False
+        # Whether the module is currently processing data
+        self._running = False
         # Holds the thread object when module threading is enabled
         self.thread = None
 
@@ -314,6 +314,16 @@ class SpiderFootPlugin():
 
         return False
 
+    @property
+    def running(self):
+        """Indicates whether the module is currently processing data.
+        Modules that process data in pools/batches typically override this method.
+
+        Returns:
+            bool
+        """
+        return self._running
+
     def watchedEvents(self):
         """What events is this module interested in for input. The format is a list
         of event types that are applied to event types that this module wants to
@@ -387,14 +397,14 @@ class SpiderFootPlugin():
             while not self.checkForStop():
                 try:
                     sfEvent = self.incomingEventQueue.get_nowait()
-                    self.running = True
+                    self._running = True
                     if sfEvent == 'FINISHED':
                         self.sf.debug(f"{self.__name__}.threadWorker() got \"FINISHED\" from incomingEventQueue.")
                         self.finish()
                     else:
                         self.sf.debug(f"{self.__name__}.threadWorker() got event, {sfEvent.eventType}, from incomingEventQueue.")
                         self.handleEvent(sfEvent)
-                    self.running = False
+                    self._running = False
                 except queue.Empty:
                     sleep(.3)
                     continue
@@ -407,6 +417,194 @@ class SpiderFootPlugin():
                           + traceback.format_exc())
             self.errorState = True
         finally:
-            self.running = False
+            self._running = False
+
+    class ThreadPool:
+        """
+        A spiderfoot-integrated threading pool
+        Each thread in the pool is spawned only once, and reused for best performance.
+
+        Example 1: using map()
+            with self.threadPool(self.opts["_maxthreads"]) as pool:
+                # callback("a", "arg1", kwarg1="kwarg1"), callback("b", "arg1" ...)
+                for result in pool.map(
+                        callback,
+                        ["a", "b", "c", "d"],
+                        args=("arg1",)
+                        kwargs={kwarg1: "kwarg1"}
+                    ):
+                    yield result
+
+        Example 2: using submit()
+            with self.threadPool(self.opts["_maxthreads"]) as pool:
+                pool.start(callback, "arg1", kwarg1="kwarg1")
+                # callback(a, "arg1", kwarg1="kwarg1"), callback(b, "arg1" ...)
+                pool.submit(a)
+                pool.submit(b)
+                for result in pool.shutdown():
+                    yield result
+        """
+
+        def __init__(self, sfp, threads=100, qsize=None, name=None):
+            if name is None:
+                name = ""
+
+            self.sfp = sfp
+            self.threads = int(threads)
+            try:
+                self.qsize = int(qsize)
+            except (TypeError, ValueError):
+                self.qsize = self.threads * 2
+            self.pool = [None] * self.threads
+            self.name = str(name)
+            self.inputThread = None
+            self.inputQueue = queue.Queue(self.qsize)
+            self.outputQueue = queue.Queue(self.qsize)
+            self.stop = False
+
+        def start(self, callback, *args, **kwargs):
+            self.sfp.sf.debug(f'Starting thread pool "{self.name}" with {self.threads:,} threads')
+            for i in range(self.threads):
+                name = kwargs.get('name', 'worker')
+                t = ThreadPoolWorker(self.sfp, target=callback, args=args, kwargs=kwargs,
+                                     inputQueue=self.inputQueue, outputQueue=self.outputQueue,
+                                     name=f"{self.name}_{name}_{i + 1}")
+                t.start()
+                self.pool[i] = t
+
+        def shutdown(self, wait=True):
+            self.sfp.sf.debug(f'Shutting down thread pool "{self.name}" with wait={wait}')
+            if wait:
+                while not self.finished and not self.sfp.checkForStop():
+                    yield from self.results
+                    sleep(.1)
+            self.stop = True
+            for t in self.pool:
+                with suppress(Exception):
+                    t.stop = True
+            # make sure input queue is empty
+            with suppress(Exception):
+                while 1:
+                    self.inputQueue.get_nowait()
+            with suppress(Exception):
+                self.inputQueue.close()
+            yield from self.results
+            with suppress(Exception):
+                self.outputQueue.close()
+
+        def submit(self, arg, wait=True):
+            self.inputQueue.put_nowait(arg)
+
+        def map(self, callback, iterable, args=None, kwargs=None, name=""):  # noqa: A003
+            """
+            Args:
+                iterable: each entry will be passed as the first argument to the function
+                callback: the function to thread
+                args: additional arguments to pass to callback function
+                kwargs: keyword arguments to pass to callback function
+                name: base name to use for all the threads
+
+            Yields:
+                return values from completed callback function
+            """
+
+            if args is None:
+                args = tuple()
+
+            if kwargs is None:
+                kwargs = dict()
+
+            self.inputThread = threading.Thread(target=self.feedQueue, args=(iterable, self.inputQueue))
+            self.inputThread.start()
+
+            self.start(callback, *args, **kwargs)
+            yield from self.shutdown()
+
+        @property
+        def results(self):
+            while 1:
+                try:
+                    yield self.outputQueue.get_nowait()
+                except Exception:
+                    break
+
+        def feedQueue(self, iterable, q):
+            for i in iterable:
+                if self.stop:
+                    break
+                while 1:
+                    try:
+                        q.put_nowait(i)
+                        break
+                    except queue.Full:
+                        sleep(.1)
+                        continue
+
+        @property
+        def finished(self):
+            if self.sfp.checkForStop():
+                return True
+            else:
+                finishedThreads = [not t.busy for t in self.pool if t is not None]
+                try:
+                    inputThreadAlive = self.inputThread.is_alive()
+                except AttributeError:
+                    inputThreadAlive = False
+                return not inputThreadAlive and self.inputQueue.empty() and all(finishedThreads)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exception_type, exception_value, traceback):
+            self.shutdown()
+            # Make sure queues are empty before exiting
+            with suppress(Exception):
+                for q in (self.outputQueue, self.inputQueue):
+                    while 1:
+                        try:
+                            q.get_nowait()
+                        except queue.Empty:
+                            break
+
+    def threadPool(self, *args, **kwargs):
+        return self.ThreadPool(self, *args, **kwargs)
+
+
+class ThreadPoolWorker(threading.Thread):
+
+    def __init__(self, sfp, inputQueue, outputQueue, group=None, target=None,
+                 name=None, args=None, kwargs=None, verbose=None):
+        if args is None:
+            args = tuple()
+
+        if kwargs is None:
+            kwargs = dict()
+
+        self.sfp = sfp
+        self.inputQueue = inputQueue
+        self.outputQueue = outputQueue
+        self.busy = False
+        self.stop = False
+
+        super().__init__(group, target, name, args, kwargs)
+
+    def run(self):
+        while not self.stop:
+            try:
+                entry = self.inputQueue.get_nowait()
+                self.busy = True
+                try:
+                    result = self._target(entry, *self._args, **self._kwargs)
+                except Exception:
+                    import traceback
+                    self.sfp.sf.error(f'Error in thread worker {self.name}: {traceback.format_exc()}')
+                    break
+                self.outputQueue.put(result)
+            except queue.Empty:
+                self.busy = False
+                # sleep briefly to save CPU
+                sleep(.1)
+            finally:
+                self.busy = False
 
 # end of SpiderFootPlugin class


### PR DESCRIPTION
A spiderfoot-integrated threading pool
Each thread in the pool is spawned only once, and reused for best performance.
```python
# Example 1: using map()
with self.threadPool(self.opts["_maxthreads"]) as pool:
    # callback("a", "arg1", kwarg1="kwarg1"), callback("b", "arg1" ...)
    for result in pool.map(
            callback,
            ["a", "b", "c", "d"],
            args=("arg1",)
            kwargs={kwarg1: "kwarg1"}
        ):
        yield result

# Example 2: using submit()
with self.threadPool(self.opts["_maxthreads"]) as pool:
    pool.start(callback, "arg1", kwarg1="kwarg1")
    # callback(a, "arg1", kwarg1="kwarg1"), callback(b, "arg1" ...)
    pool.submit(a)
    pool.submit(b)
    for result in pool.shutdown():
        yield result
```