### PR TITLE
Modules "threaded" attribute

### DIFF
--- a/sf.py
+++ b/sf.py
@@ -152,8 +152,9 @@ def main():
             sfModules[modName]['object'] = getattr(mod, modName)()
             mod_dict = sfModules[modName]['object'].asdict()
             sfModules[modName].update(mod_dict)
-        except BaseException as e:
-            log.critical(f"Failed to load module {modName}: {e}")
+        except BaseException:
+            import traceback
+            log.critical(f"Failed to load module {modName}: {traceback.format_exc()}")
             sys.exit(-1)
 
     if not sfModules:

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -55,6 +55,8 @@ class SpiderFootPlugin():
     incomingEventQueue = None
     # Queue for produced events
     outgoingEventQueue = None
+    # Whether to use ThreadPool
+    threaded = False
     # SpiderFoot object, set in each module's setup() function
     sf = None
     # Configuration, set in each module's setup() function
@@ -67,6 +69,10 @@ class SpiderFootPlugin():
         self._running = False
         # Holds the thread object when module threading is enabled
         self.thread = None
+        # logging overrides
+        self._log = None
+        # module threading
+        self.__threadPool = None
 
         self.log = logging.getLogger(f"spiderfoot.{__name__}")
 
@@ -328,6 +334,8 @@ class SpiderFootPlugin():
         Returns:
             bool
         """
+        if self.threaded:
+            return not self._threadPool.finished
         return self._running
 
     def watchedEvents(self):
@@ -412,7 +420,10 @@ class SpiderFootPlugin():
                     self.finish()
                 else:
                     self.sf.debug(f"{self.__name__}.threadWorker() got event, {sfEvent.eventType}, from incomingEventQueue.")
-                    self.handleEvent(sfEvent)
+                    if self.threaded:
+                        self._threadPool.submit(sfEvent)
+                    else:
+                        self.handleEvent(sfEvent)
                 self._running = False
         except KeyboardInterrupt:
             self.sf.debug(f"Interrupted module {self.__name__}.")
@@ -593,6 +604,18 @@ class SpiderFootPlugin():
 
     def threadPool(self, *args, **kwargs):
         return self.ThreadPool(self, *args, **kwargs)
+
+    @property
+    def _threadPool(self):
+        if self.threaded and self.__threadPool is None:
+            threads = self.opts.get("maxthreads", self.opts.get("_maxthreads", 10))
+            self.__threadPool = self.threadPool(
+                threads=int(threads),
+                name=self.__name__,
+                saveResults=False
+            )
+            self.__threadPool.start(self.handleEvent)
+        return self.__threadPool
 
 
 class ThreadPoolWorker(threading.Thread):

--- a/spiderfoot/plugin.py
+++ b/spiderfoot/plugin.py
@@ -443,7 +443,7 @@ class SpiderFootPlugin():
         Each thread in the pool is spawned only once, and reused for best performance.
 
         Example 1: using map()
-            with self.threadPool(self.opts["_maxthreads"]) as pool:
+            with self.threadPool(self.opts["_maxthreads"], saveResults=True) as pool:
                 # callback("a", "arg1", kwarg1="kwarg1"), callback("b", "arg1" ...)
                 for result in pool.map(
                         callback,
@@ -454,7 +454,7 @@ class SpiderFootPlugin():
                     yield result
 
         Example 2: using submit()
-            with self.threadPool(self.opts["_maxthreads"]) as pool:
+            with self.threadPool(self.opts["_maxthreads"], saveResults=True) as pool:
                 pool.start(callback, "arg1", kwarg1="kwarg1")
                 # callback(a, "arg1", kwarg1="kwarg1"), callback(b, "arg1" ...)
                 pool.submit(a)
@@ -463,7 +463,16 @@ class SpiderFootPlugin():
                     yield result
         """
 
-        def __init__(self, sfp, threads=100, qsize=None, name=None):
+        def __init__(self, sfp, threads=100, qsize=None, name=None, saveResults=False):
+            """Initialize the ThreadPool class.
+
+            Args:
+                sfp: A SpiderFootPlugin object
+                threads: Max number of threads
+                qsize: Queue size
+                name: Name
+                saveResults: Whether to store the return value of each function call
+            """
             if name is None:
                 name = ""
 
@@ -477,7 +486,10 @@ class SpiderFootPlugin():
             self.name = str(name)
             self.inputThread = None
             self.inputQueue = queue.Queue(self.qsize)
-            self.outputQueue = queue.Queue(self.qsize)
+            if saveResults:
+                self.outputQueue = queue.Queue(self.qsize)
+            else:
+                self.outputQueue = None
             self.stop = False
 
         def start(self, callback, *args, **kwargs):
@@ -540,11 +552,9 @@ class SpiderFootPlugin():
 
         @property
         def results(self):
-            while 1:
-                try:
+            with suppress(Exception):
+                while 1:
                     yield self.outputQueue.get_nowait()
-                except Exception:
-                    break
 
         def feedQueue(self, iterable, q):
             for i in iterable:
@@ -561,16 +571,14 @@ class SpiderFootPlugin():
         @property
         def finished(self):
             if self.sfp.checkForStop():
-                finished = True
+                return True
             else:
                 finishedThreads = [not t.busy for t in self.pool if t is not None]
                 try:
                     inputThreadAlive = self.inputThread.is_alive()
                 except AttributeError:
                     inputThreadAlive = False
-                finished = not inputThreadAlive and self.inputQueue.empty() and all(finishedThreads)
-            self.sfp.sf.debug(f'Finished: {finished}')
-            return finished
+                return not inputThreadAlive and self.inputQueue.empty() and all(finishedThreads)
 
         def __enter__(self):
             return self
@@ -578,13 +586,10 @@ class SpiderFootPlugin():
         def __exit__(self, exception_type, exception_value, traceback):
             self.shutdown()
             # Make sure queues are empty before exiting
-            with suppress(Exception):
-                for q in (self.outputQueue, self.inputQueue):
+            for q in (self.outputQueue, self.inputQueue):
+                with suppress(Exception):
                     while 1:
-                        try:
-                            q.get_nowait()
-                        except queue.Empty:
-                            break
+                        q.get_nowait()
 
     def threadPool(self, *args, **kwargs):
         return self.ThreadPool(self, *args, **kwargs)
@@ -592,7 +597,7 @@ class SpiderFootPlugin():
 
 class ThreadPoolWorker(threading.Thread):
 
-    def __init__(self, sfp, inputQueue, outputQueue, group=None, target=None,
+    def __init__(self, sfp, inputQueue, outputQueue=None, group=None, target=None,
                  name=None, args=None, kwargs=None, verbose=None):
         if args is None:
             args = tuple()
@@ -619,7 +624,8 @@ class ThreadPoolWorker(threading.Thread):
                     import traceback
                     self.sfp.sf.error(f'Error in thread worker {self.name}: {traceback.format_exc()}')
                     break
-                self.outputQueue.put(result)
+                if self.outputQueue is not None:
+                    self.outputQueue.put(result)
             except queue.Empty:
                 self.busy = False
                 # sleep briefly to save CPU

--- a/test/unit/spiderfoot/test_spiderfootplugin.py
+++ b/test/unit/spiderfoot/test_spiderfootplugin.py
@@ -391,7 +391,7 @@ class TestSpiderFootPlugin(unittest.TestCase):
             ("c", ("arg1",), ("kwarg1", "kwarg1"))
         ]
         # Example 1: using map()
-        with sfp.threadPool(threads) as pool:
+        with sfp.threadPool(threads, saveResults=True) as pool:
             map_results = sorted(
                 list(pool.map(
                     callback,
@@ -404,7 +404,7 @@ class TestSpiderFootPlugin(unittest.TestCase):
         self.assertEqual(map_results, expectedOutput)
 
         # Example 2: using submit()
-        with sfp.threadPool(threads) as pool:
+        with sfp.threadPool(threads, saveResults=True) as pool:
             pool.start(callback, *args, **kwargs)
             for i in iterable:
                 pool.submit(i)


### PR DESCRIPTION
This PR enables thread on any module bearing the attribute `threaded=True`. The max number of threads is determined by checking= `self.opts["maxthreads"]`, then `self.opts["_maxthreads"]`. If neither of those exist, it defaults to 10.

This only applied to scans where threading is enabled.