### PR TITLE
sfp_accounts: Change maxthreads default from 50 to 20

### DIFF
--- a/modules/sfp_accounts.py
+++ b/modules/sfp_accounts.py
@@ -36,7 +36,7 @@ class sfp_accounts(SpiderFootPlugin):
         "ignoreworddict": True,
         "musthavename": True,
         "userfromemail": True,
-        "_maxthreads": 50
+        "_maxthreads": 20
     }
 
     # Option descriptions


### PR DESCRIPTION
`50` threads is a bit high for a module which makes HTTP requests.

By default, modules which make HTTP requests have `maxthreads` set to 20 (at most).

By default, modules which make DNS requests have `maxthreads` set to 50 (or 100).
