### PR TITLE
sfwebui: Initialize database at web server startup

### DIFF
--- a/sfwebui.py
+++ b/sfwebui.py
@@ -79,7 +79,7 @@ class SpiderFootWebUi:
         # 'config' supplied will be the defaults, let's supplement them
         # now with any configuration which may have previously been saved.
         self.defaultConfig = deepcopy(config)
-        dbh = SpiderFootDb(self.defaultConfig)
+        dbh = SpiderFootDb(self.defaultConfig, init=True)
         sf = SpiderFoot(self.defaultConfig)
         self.config = sf.configUnserialize(dbh.configGet(), self.defaultConfig)
 


### PR DESCRIPTION
Untested but seems reasonable.

Fixes #1458

The database is initialized in `start_scan` in `sf.py` but not in `start_web_server`.
