### PR TITLE
removed a pitfall where the code was using a default mutable argument

### DIFF
--- a/sflib.py
+++ b/sflib.py
@@ -2364,7 +2364,7 @@ class SpiderFoot:
 
         return True
 
-    def googleIterate(self, searchString: str, opts: dict = {}) -> dict:
+    def googleIterate(self, searchString: str, opts: dict = None) -> dict:
         """Request search results from the Google API.
 
         Will return a dict:
@@ -2384,7 +2384,8 @@ class SpiderFoot:
         Returns:
             dict: Search results as {"webSearchUrl": "URL", "urls": [results]}
         """
-
+        if opts is None:
+            opts = {}
         search_string = searchString.replace(" ", "%20")
         params = urllib.parse.urlencode({
             "cx": opts["cse_id"],


### PR DESCRIPTION
**The problem**
In Python it usually dangerous to use mutable arguments like dicts or lists as default arguments in method, as is better explained [here](https://docs.python-guide.org/writing/gotchas/)

**The solution**
This PR applies a simple refactoring to remove a case where a method was created using default a mutable argument