### PR TITLE
Allow username and password to be set as environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENV PATH="/opt/venv/bin":$PATH
 COPY $REQUIREMENTS requirements.txt ./
 RUN ls
 RUN echo "$REQUIREMENTS"
+RUN pip3 install --upgrade pip
 RUN pip3 install -r "$REQUIREMENTS"
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,11 @@ services:
   spiderfoot:
     build:
        context: ./
-    image: spiderfoot
+    image: my_spiderfoot
     container_name: spiderfoot
     ports:
       - "5001:5001"
+    environment:
+      - SF_USERNAME=admin
+      - SF_PASSWORD=admin
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   spiderfoot:
     build:
        context: ./
-    image: my_spiderfoot
+    image: spiderfoot
     container_name: spiderfoot
     ports:
       - "5001:5001"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,10 @@ pygexf>=0.2.2
 PyPDF2>=1.26.0
 stem>=1.7.1
 python-whois>=0.7.1
-secure>=0.2.1
+secure==0.2.1
 pyOpenSSL>=17.5.0
 python-docx>=0.8.10
 python-pptx>=0.6.18
-networkx>=2.5
+networkx==2.5
 cryptography>=3.3.0
 publicsuffixlist>=0.7.3

--- a/sf.py
+++ b/sf.py
@@ -483,6 +483,26 @@ def start_web_server(sfWebUiConfig, sfConfig):
     }
 
     secrets = dict()
+
+    log.info("Check for username and password environment variables")
+    if 'SF_USERNAME' in os.environ.keys():
+        username = os.environ.get("SF_USERNAME")
+        log.info("found username")
+    else:
+        username = None
+    if 'SF_PASSWORD' in os.environ.keys():
+        password = os.environ.get("SF_PASSWORD")
+        log.info("found password")
+    else:
+        password = None
+    
+    # add the username and password to the secrets dictionary. 
+    if username == None or password == None:
+        log.info("No username/password environment variables defined.") 
+    else:
+        secrets[username] = password
+
+
     passwd_file = sf.dataPath() + '/passwd'
     if os.path.isfile(passwd_file):
         if not os.access(passwd_file, os.R_OK):
@@ -506,7 +526,7 @@ def start_web_server(sfWebUiConfig, sfConfig):
             secrets[u] = p
 
     if secrets:
-        log.info("Enabling authentication based on supplied passwd file.")
+        log.info("Enabling authentication based on supplied passwd file or environment variables.")
         conf['/'] = {
             'tools.auth_digest.on': True,
             'tools.auth_digest.realm': web_host,


### PR DESCRIPTION
This makes it a bit easier to run a secure instance in a Kubernetes cluster or other virtualized environments.  I also had to change the requirements file to load a specific version of networkx and secure packages.  Seems like the newest versions are not compatible.  