### PR TITLE
Move module loading to SpiderFootHelpers.loadModulesAsDict() function

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,7 @@ def default_options(request):
         '_genericusers': "abuse,admin,billing,compliance,devnull,dns,ftp,hostmaster,inoc,ispfeedback,ispsupport,list-request,list,maildaemon,marketing,noc,no-reply,noreply,null,peering,peering-notify,peering-request,phish,phishing,postmaster,privacy,registrar,registry,root,routing-registry,rr,sales,security,spam,support,sysadmin,tech,undisclosed-recipients,unsubscribe,usenet,uucp,webmaster,www",
         '__database': f"{SpiderFootHelpers.dataPath()}/spiderfoot.test.db",  # note: test database file
         '__modules__': None,  # List of modules. Will be set after start-up.
+        '__correlationrules__': None,  # List of correlation rules. Will be set after start-up.
         '_socks1type': '',
         '_socks2addr': '',
         '_socks3port': '',

--- a/test/integration/test_sfwebui.py
+++ b/test/integration/test_sfwebui.py
@@ -1,5 +1,4 @@
 # test_sfwebui.py
-import os
 import unittest
 
 import cherrypy
@@ -37,39 +36,9 @@ class TestSpiderFootWebUiRoutes(helper.CPWebCase):
             'root': '/'
         }
 
-        sfModules = dict()
         sf = SpiderFoot(default_config)
         mod_dir = sf.myPath() + '/modules/'
-        for filename in os.listdir(mod_dir):
-            if not filename.startswith("sfp_"):
-                continue
-            if not filename.endswith(".py"):
-                continue
-            # Skip the module template and debugging modules
-            if filename in ('sfp_template.py', 'sfp_stor_print.py'):
-                continue
-            modName = filename.split('.')[0]
-
-            # Load and instantiate the module
-            sfModules[modName] = dict()
-            mod = __import__('modules.' + modName, globals(), locals(), [modName])
-            sfModules[modName]['object'] = getattr(mod, modName)()
-            sfModules[modName]['name'] = sfModules[modName]['object'].meta['name']
-            sfModules[modName]['cats'] = sfModules[modName]['object'].meta.get('categories', list())
-            sfModules[modName]['group'] = sfModules[modName]['object'].meta.get('useCases', list())
-            if len(sfModules[modName]['cats']) > 1:
-                raise ValueError(f"Module {modName} has multiple categories defined but only one is supported.")
-            sfModules[modName]['labels'] = sfModules[modName]['object'].meta.get('flags', list())
-            sfModules[modName]['descr'] = sfModules[modName]['object'].meta['summary']
-            sfModules[modName]['provides'] = sfModules[modName]['object'].producedEvents()
-            sfModules[modName]['consumes'] = sfModules[modName]['object'].watchedEvents()
-            sfModules[modName]['meta'] = sfModules[modName]['object'].meta
-            if hasattr(sfModules[modName]['object'], 'opts'):
-                sfModules[modName]['opts'] = sfModules[modName]['object'].opts
-            if hasattr(sfModules[modName]['object'], 'optdescs'):
-                sfModules[modName]['optdescs'] = sfModules[modName]['object'].optdescs
-
-        default_config['__modules__'] = sfModules
+        default_config['__modules__'] = SpiderFootHelpers.loadModulesAsDict(mod_dir)
 
         conf = {
             '/query': {

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -1,10 +1,10 @@
-# test_spiderfoot_module_loading.py
-import os
+# test_modules.py
 import pytest
 import unittest
 
 from sflib import SpiderFoot
 from spiderfoot import SpiderFootDb
+from spiderfoot import SpiderFootHelpers
 
 
 @pytest.mark.usefixtures
@@ -15,25 +15,8 @@ class TestSpiderFootModuleLoading(unittest.TestCase):
 
     @staticmethod
     def load_modules(sf):
-        # Go through each module in the modules directory with a .py extension
-        sfModules = dict()
         mod_dir = sf.myPath() + '/modules/'
-        for filename in os.listdir(mod_dir):
-            if not filename.startswith("sfp_"):
-                continue
-            if not filename.endswith(".py"):
-                continue
-
-            modName = filename.split('.')[0]
-
-            # Load and instantiate the module
-            sfModules[modName] = dict()
-            mod = __import__('modules.' + modName, globals(), locals(), [modName])
-            sfModules[modName]['object'] = getattr(mod, modName)()
-            mod_dict = sfModules[modName]['object'].asdict()
-            sfModules[modName].update(mod_dict)
-
-        return sfModules
+        return SpiderFootHelpers.loadModulesAsDict(mod_dir)
 
     def test_module_use_cases_are_valid(self):
         sf = SpiderFoot(self.default_options)


### PR DESCRIPTION
This has been on the todo list for a long time. Consolidates the module loading, parsing and sanity checking into one helper function.

