### PR TITLE
Modules: Keep module meta useCases array items on single line

### DIFF
--- a/modules/sfp_tool_nuclei.py
+++ b/modules/sfp_tool_nuclei.py
@@ -31,10 +31,7 @@ class sfp_tool_nuclei(SpiderFootPlugin):
             "slow",
             "invasive"
         ],
-        "useCases": [
-            "Footprint",
-            "Investigate"
-        ],
+        "useCases": ["Footprint", "Investigate"],
         "categories": ["Crawling and Scanning"],
         "toolDetails": {
             "name": "Nuclei",

--- a/modules/sfp_tool_retirejs.py
+++ b/modules/sfp_tool_retirejs.py
@@ -26,10 +26,7 @@ class sfp_tool_retirejs(SpiderFootPlugin):
         "name": "Tool - Retire.js",
         "summary": "Scanner detecting the use of JavaScript libraries with known vulnerabilities",
         "flags": ["tool"],
-        "useCases": [
-            "Footprint",
-            "Investigate"
-        ],
+        "useCases": ["Footprint", "Investigate"],
         "categories": ["Content Analysis"],
         "toolDetails": {
             "name": "Retire.js",

--- a/modules/sfp_tool_wappalyzer.py
+++ b/modules/sfp_tool_wappalyzer.py
@@ -25,10 +25,7 @@ class sfp_tool_wappalyzer(SpiderFootPlugin):
         "name": "Tool - Wappalyzer",
         "summary": "Wappalyzer indentifies technologies on websites.",
         "flags": ["tool"],
-        "useCases": [
-            "Footprint",
-            "Investigate"
-        ],
+        "useCases": ["Footprint", "Investigate"],
         "categories": ["Content Analysis"],
         "toolDetails": {
             "name": "Wappalyzer",


### PR DESCRIPTION
This makes them grepable.

Helping users on GitHub and Discord has required grepping modules on dozens of occasions.
