### PR TITLE
sfp_stackoverflow: Cleanup and add tests

### DIFF
--- a/test/unit/modules/test_sfp_stackoverflow.py
+++ b/test/unit/modules/test_sfp_stackoverflow.py
@@ -1,0 +1,34 @@
+# test_sfp_stackoverflow.py
+import pytest
+import unittest
+
+from modules.sfp_stackoverflow import sfp_stackoverflow
+from sflib import SpiderFoot
+
+
+@pytest.mark.usefixtures
+class TestModuleStackoverflow(unittest.TestCase):
+    """
+    Test modules.sfp_stackoverflow
+    """
+
+    def test_opts(self):
+        module = sfp_stackoverflow()
+        self.assertEqual(len(module.opts), len(module.optdescs))
+
+    def test_setup(self):
+        """
+        Test setup(self, sfc, userOpts=dict())
+        """
+        sf = SpiderFoot(self.default_options)
+
+        module = sfp_stackoverflow()
+        module.setup(sf, dict())
+
+    def test_watchedEvents_should_return_list(self):
+        module = sfp_stackoverflow()
+        self.assertIsInstance(module.watchedEvents(), list)
+
+    def test_producedEvents_should_return_list(self):
+        module = sfp_stackoverflow()
+        self.assertIsInstance(module.producedEvents(), list)


### PR DESCRIPTION
This fixes a design flaw in the `sfp_stackoverflow` module. The module tries to setup the `sfp_names` module and force it to handle an event. This goes against the SpiderFoot architecture. This is also unnecessary if the `sfp_names` module was included in the scan. If this was any other module it would usually be a minor inconvenience. Unfortunately, the `sfp_names` module loads multiple dictionaries during startup, resulting in a `list` of almost 900 thousand entries every time the module encountered a username. This causes issues on systems with ~2GB RAM or less.

Also reports IP addresses as affiliates `AFFILIATE_IPADDR` / `AFFILIATE_IPV6_ADDRESS` rathar then `IP_ADDRESS` / `IPV6_ADDRESS`.
