### PR TITLE
Tests: Ignore module integration tests on CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
           flake8 . --count --show-source --statistics
       - name: Test with pytest
         run: |
-          python -m pytest -n auto --dist loadfile --durations=5 --cov-report term --cov=. .
+          python -m pytest -n auto --dist loadfile --ignore=test/integration/modules/ --durations=5 --cov-report term --cov=. .
       - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
Eventually I'll move module integration tests to the `test/integration/modules/ directory.

This change lets us keep module integration tests in the repository, but skips running them on CI. These tests are often temperamental and rely on third-parties which may be down temporarily when the tests run. They may also not appreciate receiving six queries every time the CI tests run (3 versions of Python * 2 OS).
