### PR TITLE
Threat Jammer module for blacklist/malicious IP

### DIFF
--- a/modules/sfp_threatjammer.py
+++ b/modules/sfp_threatjammer.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# -------------------------------------------------------------------------------
+# Name:        sfp_threatjammer
+# Purpose:     Check if an IP or netblock is malicious according to ThreatJammer.com.
+#
+# Author:      diego.parrilla.santamaria@gmail.com
+#
+# Created:     05/05/2022
+# Copyright:   (c) Diego Parrilla 2022
+# Licence:     GPL
+# -------------------------------------------------------------------------------
+
+import json
+import time
+
+from spiderfoot import SpiderFootEvent, SpiderFootPlugin
+
+
+class sfp_threatjammer(SpiderFootPlugin):
+
+    meta = {
+        'name': "Threat Jammer",
+        'summary': "Check if an IP or netblock is malicious according to ThreatJammer.com",
+        'flags': ["apikey"],
+        'useCases': ["Passive", "Investigate"],
+        'categories': ["Reputation Systems"],
+        'dataSource': {
+            'website': "https://threatjammer.com",
+            'model': "FREE_AUTH_LIMITED",
+            'references': [
+                "https://threatjammer.com/docs/what-is-threat-jammer",
+                "https://threatjammer.com/docs/how-threat-jammer-works",
+                "https://threatjammer.com/docs/introduction-threat-jammer-user-api",
+                "https://threatjammer.com/docs/introduction-threat-jammer-report-api",
+                "https://threatjammer.com/tutorials/how-to-configure-fail2ban-in-ubuntu",
+                "https://threatjammer.com/tutorials/how-to-configure-cowrie-honeypot"
+            ],
+            'apiKeyInstructions': [
+                "https://threatjammer.com/docs/threat-jammer-api-keys",
+                "Register a new account with an email",
+                "Navigate to https://threatjammer.com/keys",
+                "The API Keys are listed under 'API Key' column"
+            ],
+            'favIcon': "https://threatjammer.com/favicon.ico",
+            'logo': "https://threatjammer.com/threatjammer-risk-score.png",
+            'description': "Threat Jammer is a service to access high-quality threat intelligence"
+            " data from a variety of sources, and integrate it into their applications with the"
+            " sole purpose of detecting and blocking malicious activity."
+        }
+    }
+
+    opts = {
+        'api_key': '',
+        "risk_score_min": 35,
+        'checkaffiliates': True,
+    }
+
+    optdescs = {
+        'api_key': "ThreatJammer.com API key.",
+        "risk_score_min": "Minimum Threat Jammer risk score.",
+        'checkaffiliates': "Apply checks to affiliates?",
+    }
+
+    results = None
+
+    def setup(self, sfc, userOpts=dict()):
+        self.sf = sfc
+        self.results = self.tempStorage()
+
+        for opt in list(userOpts.keys()):
+            self.opts[opt] = userOpts[opt]
+
+    def watchedEvents(self):
+        return [
+            "IP_ADDRESS",
+            "IPV6_ADDRESS",
+            "AFFILIATE_IPADDR",
+            "AFFILIATE_IPV6_ADDRESS",
+        ]
+
+    def producedEvents(self):
+        return [
+            "BLACKLISTED_IPADDR",
+            "BLACKLISTED_AFFILIATE_IPADDR",
+            "MALICIOUS_IPADDR",
+            "MALICIOUS_AFFILIATE_IPADDR",
+        ]
+
+    def queryIp(self, ip):
+        """Query API for an IPv4 or IPv6 address.
+
+        Args:
+            ip (str): IP address
+
+        Returns:
+            str: API response as JSON
+        """
+
+        headers = {
+            'Authorization': f"Bearer {self.opts['api_key']}",
+            'Accept': 'application/json',
+        }
+
+        res = self.sf.fetchUrl(
+            f"https://dublin.api.threatjammer.com/v1/assess/ip/{ip}",
+            timeout=self.opts['_fetchtimeout'],
+            useragent=self.opts['_useragent'],
+            headers=headers
+        )
+
+        time.sleep(1)
+
+        if res['code'] == '429':
+            self.error("You are being rate-limited by ThreatJammer.com")
+            self.errorState = True
+            return None
+
+        if res['code'] != "200":
+            self.error("Error retrieving search results from ThreatJammer.com")
+            self.errorState = True
+            return None
+
+        if res['content'] is None:
+            self.error("Received no content from ThreatJammer.com")
+            self.errorState = True
+            return None
+
+        try:
+            return json.loads(res['content'])
+        except Exception as e:
+            self.debug(f"Error processing JSON response: {e}")
+            return None
+
+        return None
+
+    def handleEvent(self, event):
+        eventName = event.eventType
+        srcModuleName = event.module
+        eventData = event.data
+
+        self.debug(f"Received event, {eventName}, from {srcModuleName}")
+
+        if self.opts["api_key"] == "":
+            self.error(
+                f"You enabled {self.__class__.__name__} but did not set an API key!"
+            )
+            self.errorState = True
+            return
+
+        if eventData in self.results:
+            self.debug(f"Skipping {eventData}, already checked.")
+            return
+
+        self.results[eventData] = True
+
+        if eventName.startswith("AFFILIATE") and not self.opts['checkaffiliates']:
+            return
+
+        if eventName in ['IP_ADDRESS', 'IPV6_ADDRESS']:
+            blacklist_type = "BLACKLISTED_IPADDR"
+            malicious_type = 'MALICIOUS_IPADDR'
+        elif eventName in ['AFFILIATE_IPADDR', 'AFFILIATE_IPV6_ADDRESS']:
+            blacklist_type = "BLACKLISTED_AFFILIATE_IPADDR"
+            malicious_type = 'MALICIOUS_AFFILIATE_IPADDR'
+        else:
+            self.debug(f"Unexpected event type {eventName}, skipping")
+            return
+
+        self.debug(f"Checking maliciousness of IP address {eventData} with ThreatJammer.com")
+
+        ip_info = self.queryIp(eventData)
+
+        if ip_info is None:
+            self.sf.error(f"Error processing JSON response for {eventData} from ThreatJammer.com")
+            return
+
+        risk_score = int(ip_info["score"])
+        risk = ip_info["risk"]
+
+        if risk_score < self.opts["risk_score_min"]:
+            self.debug(f"Skipping {eventData} for ThreatJammer.com, risk score below minimum threshold.")
+            return
+
+        url = "https://threatjammer.com/info/"
+        detail = f"""Risk score: {risk_score} ({risk})\n<SFURL>{url}{eventData}</SFURL>"""
+
+        self.info(f"Malicious IP address {eventData} found in any Threat Jammer lists")
+
+        evt = SpiderFootEvent(
+            malicious_type,
+            f"Threat Jammer - {detail}",
+            self.__name__,
+            event
+        )
+        self.notifyListeners(evt)
+
+        evt = SpiderFootEvent(
+            blacklist_type,
+            f"Threat Jammer  - {detail}",
+            self.__name__,
+            event
+        )
+        self.notifyListeners(evt)
+
+# End of sfp_threatjammer class

--- a/modules/sfp_threatjammer.py
+++ b/modules/sfp_threatjammer.py
@@ -7,7 +7,7 @@
 #
 # Created:     2022-05-03
 # Copyright:   (c) Diego Parrilla 2022
-# Licence:     GPL
+# Licence:     MIT
 # -------------------------------------------------------------------------------
 
 import json
@@ -114,6 +114,14 @@ class sfp_threatjammer(SpiderFootPlugin):
 
         time.sleep(1)
 
+        if res['code'] == '400':
+            self.error("ThreatJammer.com rejected the IP address. Use only public IP addresses.")
+            return None
+
+        if res['code'] == '422':
+            self.error("ThreatJammer.com could not process the IP address. Check the format.")
+            return None
+
         if res['code'] == '429':
             self.error("You are being rate-limited by ThreatJammer.com")
             self.errorState = True
@@ -121,16 +129,6 @@ class sfp_threatjammer(SpiderFootPlugin):
 
         if res['code'] == '401':
             self.error("You are not authorized by ThreatJammer.com. Check your API key.")
-            self.errorState = True
-            return None
-
-        if res['code'] == '400':
-            self.error("ThreatJammer.com rejected the IP address. Use only public IP addresses.")
-            self.errorState = True
-            return None
-
-        if res['code'] == '422':
-            self.error("ThreatJammer.com could not process the IP address. Check the format.")
             self.errorState = True
             return None
 
@@ -205,7 +203,7 @@ class sfp_threatjammer(SpiderFootPlugin):
             return
         risk_score = int(score)
 
-        risk = ip_info["risk"]
+        risk = ip_info.get("risk")
         if not risk:
             self.sf.error(f"No risk type found for {eventData} from ThreatJammer.com. Skipping.")
             return


### PR DESCRIPTION
# ThreatJammer module
<p align="center">
<img src="https://threatjammer.com/threatjammer-risk-score.png"  width="400" height="200" />
</p>

## Introduction
### Why a module for Threat Jammer?

[ThreatJammer.com](https://threatjammer.com/) is a service that allows developers, security engineers, and other IT professionals to access high-quality threat intelligence data from a variety of sources and integrate it into their applications with the sole purpose of detecting and blocking malicious activity.

The assessment endpoint of the API returns a risk score with the estimated probability of being a malicious IP address. Less than 35 means Low risk, and more than 67 means High risk. This is the API endpoint used in the module for IPv4 and IPv6 addresses for the BLACKLISTED_IPADDR and MALICIOUS_IPADDR events.

Anybody can sign up and use the service for free forever. 

## Getting Started
### Quick start

To use the module the user must [sign up and obtain an API KEY](https://threatjammer.com/docs/threat-jammer-api-keys). The sign-up is free forever. 

Once the developers have obtained an API Key, they have to enable the module in the `Settings` section and populate the options:
- *API hostname*: [Mandatory] The hostname where the API endpoint runs. By default `dublin.api.threatjammer.com`. 
- *API key*: [Mandatory] The API key obtained when signing up.
- *Minimum Threat Jammer risk score*: [Mandatory] The minimum integer from 0 to 99 is the threshold of the risk sensitivity. An IP address with less score than the given will be discarded and not displayed. 

Don't forget to click on the `Save Changes` button.

## About the Module
### Python and OS versions

The code has passed the tests implemented in the CI workflows, as expected. This module is compatible with versions of Python from v3.7 and up.

This module should be considered a beta version.
