### PR TITLE
codecov: Ignore test directory

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,2 @@
+ignore:
+  - "test/"


### PR DESCRIPTION
This is a test to see if we want to exclude the tests in the `test` directory from code coverage - presuming it works.
