### PR TITLE
SpiderFootDb: Add vacuumDB() function to clear unused database file pages

### DIFF
--- a/sfwebui.py
+++ b/sfwebui.py
@@ -1475,6 +1475,17 @@ class SpiderFootWebUi:
 
         return ""
 
+    @cherrypy.expose
+    @cherrypy.tools.json_out()
+    def vacuum(self):
+        dbh = SpiderFootDb(self.config)
+        try:
+            if dbh.vacuumDB():
+                return json.dumps(["SUCCESS", ""]).encode('utf-8')
+            return json.dumps(["ERROR", "Vacuuming the database failed"]).encode('utf-8')
+        except Exception as e:
+            return json.dumps(["ERROR", f"Vacuuming the database failed: {e}"]).encode('utf-8')
+
     #
     # DATA PROVIDERS
     #

--- a/spiderfoot/db.py
+++ b/spiderfoot/db.py
@@ -427,6 +427,24 @@ class SpiderFootDb:
         with self.dbhLock:
             self.dbh.close()
 
+    def vacuumDB(self) -> None:
+        """Vacuum the database. Clears unused database file pages.
+
+        Returns:
+            bool: success
+
+        Raises:
+            IOError: database I/O failed
+        """
+        with self.dbhLock:
+            try:
+                self.dbh.execute("VACUUM")
+                self.conn.commit()
+                return True
+            except sqlite3.Error as e:
+                raise IOError("SQL error encountered when vacuuming the database") from e
+        return False
+
     def search(self, criteria: dict, filterFp: bool = False) -> list:
         """Search database.
 


### PR DESCRIPTION
Fixes #310

The `vacuumDB()` function is accessible via an undocumented `/vacuum` URL route.
