### PR TITLE
Modules: Fix maxnetblock size check in several modules

### DIFF
--- a/modules/sfp_alienvault.py
+++ b/modules/sfp_alienvault.py
@@ -350,7 +350,6 @@ class sfp_alienvault(SpiderFootPlugin):
             else:
                 max_netblock = self.opts['maxnetblock']
 
-            max_netblock = self.opts['maxnetblock']
             if IPNetwork(eventData).prefixlen < max_netblock:
                 self.debug(f"Network size bigger than permitted: {IPNetwork(eventData).prefixlen} > {max_netblock}")
                 return

--- a/modules/sfp_fraudguard.py
+++ b/modules/sfp_fraudguard.py
@@ -187,7 +187,6 @@ class sfp_fraudguard(SpiderFootPlugin):
             else:
                 max_netblock = self.opts['maxnetblock']
 
-            max_netblock = self.opts['maxnetblock']
             if IPNetwork(eventData).prefixlen < max_netblock:
                 self.debug(f"Network size bigger than permitted: {IPNetwork(eventData).prefixlen} > {max_netblock}")
                 return
@@ -246,7 +245,7 @@ class sfp_fraudguard(SpiderFootPlugin):
             if eventName == 'NETBLOCK_OWNER':
                 pevent = SpiderFootEvent("IP_ADDRESS", addr, self.__name__, event)
                 self.notifyListeners(pevent)
-            if eventName == 'NETBLOCKV6_OWNER':
+            elif eventName == 'NETBLOCKV6_OWNER':
                 pevent = SpiderFootEvent("IPV6_ADDRESS", addr, self.__name__, event)
                 self.notifyListeners(pevent)
             elif eventName == 'NETBLOCK_MEMBER':

--- a/modules/sfp_pulsedive.py
+++ b/modules/sfp_pulsedive.py
@@ -176,7 +176,6 @@ class sfp_pulsedive(SpiderFootPlugin):
             else:
                 max_netblock = self.opts['maxnetblock']
 
-            max_netblock = self.opts['maxnetblock']
             if IPNetwork(eventData).prefixlen < max_netblock:
                 self.debug(f"Network size bigger than permitted: {IPNetwork(eventData).prefixlen} > {max_netblock}")
                 return

--- a/modules/sfp_robtex.py
+++ b/modules/sfp_robtex.py
@@ -127,7 +127,6 @@ class sfp_robtex(SpiderFootPlugin):
             else:
                 max_netblock = self.opts['maxnetblock']
 
-            max_netblock = self.opts['maxnetblock']
             if IPNetwork(eventData).prefixlen < max_netblock:
                 self.debug(f"Network size bigger than permitted: {IPNetwork(eventData).prefixlen} > {max_netblock}")
                 return


### PR DESCRIPTION
In some modules `max_netblock` is defined then subsequently overwritten with a potentially invalid value.
