### PR TITLE
Made copying and pasting from the README.md to terminal easier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,20 +95,20 @@ To install and run SpiderFoot, you need at least Python 3.7 and a number of Pyth
 #### Stable build (packaged release):
 
 ```
-$ wget https://github.com/smicallef/spiderfoot/archive/v4.0.tar.gz
-$ tar zxvf v4.0.tar.gz
-$ cd spiderfoot-4.0
-$ pip3 install -r requirements.txt
-$ python3 ./sf.py -l 127.0.0.1:5001
+ wget https://github.com/smicallef/spiderfoot/archive/v4.0.tar.gz
+ tar zxvf v4.0.tar.gz
+ cd spiderfoot-4.0
+ pip3 install -r requirements.txt
+ python3 ./sf.py -l 127.0.0.1:5001
 ```
 
 #### Development build (cloning git master branch):
 
 ```
-$ git clone https://github.com/smicallef/spiderfoot.git
-$ cd spiderfoot
-$ pip3 install -r requirements.txt
-$ python3 ./sf.py -l 127.0.0.1:5001
+ git clone https://github.com/smicallef/spiderfoot.git
+ cd spiderfoot
+ pip3 install -r requirements.txt
+ python3 ./sf.py -l 127.0.0.1:5001
 ```
 
 Check out the [documentation](https://www.spiderfoot.net/documentation) and our [asciinema videos](https://asciinema.org/~spiderfoot) for more tutorials.


### PR DESCRIPTION
### Here is the problem , when you click the copy to clipboard button the $ signs also copy with them . It makes difficult to run all commands at once, the user will have to go back and forth to copy every command manual(I know $ is used to show terminal usage but a user is  already  aware of that ).
![image](https://user-images.githubusercontent.com/66710785/198291681-91548563-34c2-439a-a217-c95d45138bf5.png)

![image](https://user-images.githubusercontent.com/66710785/198292386-6d896567-4eb3-44d4-8506-be7807c88e65.png)

![image](https://user-images.githubusercontent.com/66710785/198292448-8de3aaaf-97c0-4b1b-bf65-5929c7fdb4c0.png)


Hence just to make it little more convenient for the users , please merge my pull request :).