### PR TITLE
Company name and cert event fixes

### DIFF
--- a/modules/common_ssl_cert.py
+++ b/modules/common_ssl_cert.py
@@ -1,0 +1,47 @@
+from spiderfoot import SpiderFootEvent
+
+def process_ssl_cert_events(spiderfoot_plugin, cert, root_event):
+    eventName = root_event.eventType
+    
+    if cert.get('issued'):
+            new_event = SpiderFootEvent('SSL_CERTIFICATE_ISSUED', cert['issued'], spiderfoot_plugin.__name__, root_event)
+            spiderfoot_plugin.notifyListeners(new_event)
+
+    if cert.get('issuer'):
+            new_event = SpiderFootEvent('SSL_CERTIFICATE_ISSUER', cert['issuer'], spiderfoot_plugin.__name__, root_event)
+            spiderfoot_plugin.notifyListeners(new_event)
+
+    if eventName != "IP_ADDRESS" and cert.get('mismatch'):
+            new_event = SpiderFootEvent('SSL_CERTIFICATE_MISMATCH', ', '.join(cert.get('hosts')), spiderfoot_plugin.__name__, root_event)
+            spiderfoot_plugin.notifyListeners(new_event)
+
+    for san in set(cert.get('altnames', list())):
+            domain = san.replace("*.", "")
+
+            if spiderfoot_plugin.getTarget().matches(domain, includeChildren=True):
+                    new_event_type = 'INTERNET_NAME'
+                    if spiderfoot_plugin.opts['verify'] and not spiderfoot_plugin.sf.resolveHost(domain) and not spiderfoot_plugin.sf.resolveHost6(domain):
+                            spiderfoot_plugin.debug(f"Host {domain} could not be resolved")
+                            new_event_type += '_UNRESOLVED'
+            else:
+                    new_event_type = 'CO_HOSTED_SITE'
+
+            new_event = SpiderFootEvent(new_event_type, domain, spiderfoot_plugin.__name__, root_event)
+            spiderfoot_plugin.notifyListeners(new_event)
+
+            if spiderfoot_plugin.sf.isDomain(domain, spiderfoot_plugin.opts['_internettlds']):
+                    if new_event_type == 'CO_HOSTED_SITE':
+                            new_event = SpiderFootEvent('CO_HOSTED_SITE_DOMAIN', domain, spiderfoot_plugin.__name__, root_event)
+                            spiderfoot_plugin.notifyListeners(new_event)
+                    else:
+                            new_event = SpiderFootEvent('DOMAIN_NAME', domain, spiderfoot_plugin.__name__, root_event)
+                            spiderfoot_plugin.notifyListeners(new_event)
+
+    if cert.get('expired'):
+            new_event = SpiderFootEvent("SSL_CERTIFICATE_EXPIRED", cert.get('expirystr', 'Unknown'), spiderfoot_plugin.__name__, root_event)
+            spiderfoot_plugin.notifyListeners(new_event)
+            return
+
+    if cert.get('expiring'):
+            new_event = SpiderFootEvent("SSL_CERTIFICATE_EXPIRING", cert.get('expirystr', 'Unknown'), spiderfoot_plugin.__name__, root_event)
+            spiderfoot_plugin.notifyListeners(new_event)

--- a/modules/sfp_sslcert.py
+++ b/modules/sfp_sslcert.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 
 from spiderfoot import SpiderFootEvent, SpiderFootPlugin
 
+from modules.common_ssl_cert import process_ssl_cert_events
 
 class sfp_sslcert(SpiderFootPlugin):
 
@@ -128,47 +129,8 @@ class sfp_sslcert(SpiderFootPlugin):
         rawevt = SpiderFootEvent("SSL_CERTIFICATE_RAW", cert['text'], self.__name__, event)
         self.notifyListeners(rawevt)
 
-        if cert.get('issued'):
-            evt = SpiderFootEvent('SSL_CERTIFICATE_ISSUED', cert['issued'], self.__name__, event)
-            self.notifyListeners(evt)
+        process_ssl_cert_events(self, cert, event)
 
-        if cert.get('issuer'):
-            evt = SpiderFootEvent('SSL_CERTIFICATE_ISSUER', cert['issuer'], self.__name__, event)
-            self.notifyListeners(evt)
-
-        if eventName != "IP_ADDRESS" and cert.get('mismatch'):
-            evt = SpiderFootEvent('SSL_CERTIFICATE_MISMATCH', ', '.join(cert.get('hosts')), self.__name__, event)
-            self.notifyListeners(evt)
-
-        for san in set(cert.get('altnames', list())):
-            domain = san.replace("*.", "")
-
-            if self.getTarget().matches(domain, includeChildren=True):
-                evt_type = 'INTERNET_NAME'
-                if self.opts['verify'] and not self.sf.resolveHost(domain) and not self.sf.resolveHost6(domain):
-                    self.debug(f"Host {domain} could not be resolved")
-                    evt_type += '_UNRESOLVED'
-            else:
-                evt_type = 'CO_HOSTED_SITE'
-
-            evt = SpiderFootEvent(evt_type, domain, self.__name__, event)
-            self.notifyListeners(evt)
-
-            if self.sf.isDomain(domain, self.opts['_internettlds']):
-                if evt_type == 'CO_HOSTED_SITE':
-                    evt = SpiderFootEvent('CO_HOSTED_SITE_DOMAIN', domain, self.__name__, event)
-                    self.notifyListeners(evt)
-                else:
-                    evt = SpiderFootEvent('DOMAIN_NAME', domain, self.__name__, event)
-                    self.notifyListeners(evt)
-
-        if cert.get('expired'):
-            evt = SpiderFootEvent("SSL_CERTIFICATE_EXPIRED", cert.get('expirystr', 'Unknown'), self.__name__, event)
-            self.notifyListeners(evt)
-            return
-
-        if cert.get('expiring'):
-            evt = SpiderFootEvent("SSL_CERTIFICATE_EXPIRING", cert.get('expirystr', 'Unknown'), self.__name__, event)
-            self.notifyListeners(evt)
+        
 
 # End of sfp_sslcert class


### PR DESCRIPTION
1. Moved common SSL event functions to common_ssl_cert.py
2. Change sfp_crt and sfp_sslcert accordingly.
3. Allowed sfp_company to grab the O= portion of cert subject as full name (not limited to 3 words)

fixes #1749