### PR TITLE
sfp_fsecure_riddler: Check for login failure

### DIFF
--- a/modules/sfp_fsecure_riddler.py
+++ b/modules/sfp_fsecure_riddler.py
@@ -137,8 +137,8 @@ class sfp_fsecure_riddler(SpiderFootPlugin):
 
         time.sleep(1)
 
-        if res['code'] in ["400", "401", "402", "403"]:
-            self.error('Unexpected HTTP response code: ' + res['code'])
+        if res['code'] in ["400", "401", "402", "403", "500"]:
+            self.error(f"Unexpected HTTP response code {res['code']} from F-Secure Riddler")
             self.errorState = True
             return None
 
@@ -152,7 +152,7 @@ class sfp_fsecure_riddler(SpiderFootPlugin):
             return None
 
         if not data:
-            self.debug("No results found for " + qry)
+            self.debug(f"No results found for {qry}")
             return None
 
         return data
@@ -168,7 +168,7 @@ class sfp_fsecure_riddler(SpiderFootPlugin):
         self.debug(f"Received event, {eventName}, from {srcModuleName}")
 
         if srcModuleName == 'sfp_fsecure_riddler':
-            self.debug("Ignoring " + eventData + ", from self.")
+            self.debug(f"Ignoring {eventName}, from self.")
             return
 
         if eventData in self.results:
@@ -183,6 +183,11 @@ class sfp_fsecure_riddler(SpiderFootPlugin):
         if not self.token:
             self.login()
 
+            if not self.token:
+                self.error('Could not login to F-Secure Riddler')
+                self.errorState = True
+                return
+
         self.results[eventData] = True
 
         data = None
@@ -193,7 +198,7 @@ class sfp_fsecure_riddler(SpiderFootPlugin):
             data = self.query("ip:" + eventData)
 
         if not data:
-            self.info("No results found for " + eventData)
+            self.info(f"No results found for {eventData}")
             return
 
         e = SpiderFootEvent('RAW_RIR_DATA', str(data), self.__name__, event)


### PR DESCRIPTION
[F-Secure Riddler](https://riddler.io/) has been having intermittent issues since late 2022, sometimes returning a HTTP 500 error:

* http://web.archive.org/web/20221224052214/https://riddler.io/

At time of writing it is currently returning a HTTP 500 error for both the landing page and the API.

![F-Secure Riddler HTTP 500 error](https://user-images.githubusercontent.com/434827/219909928-b7de4020-cb51-4485-8d43-bf707cbe897e.png)

This PR fixes a bug where login failure was not checked correctly, causing the module to continue to run without a valid login token.

This was particularly problematic, as this caused the module to attempt to login every time the module received an event. Worse, this module contains a one second sleep in the `query` function. As such, every watched event was generating a login HTTP request, and a query HTTP request which was doomed to failure, followed by a one second delay.



# Before
```
2023-02-18 21:23:46,413 [DEBUG] sflib : Modules running: 1 (sfp_fsecure_riddler)
2023-02-18 21:23:47,332 [ERROR] threadpool : Error in thread worker sharedThreadPool_worker_3: Traceback (most recent call last):
  File "/root/Desktop/spiderfoot/spiderfoot/threadpool.py", line 255, in run
    result = callback(*args, **kwargs)
  File "/root/Desktop/spiderfoot/modules/sfp_fsecure_riddler.py", line 207, in handleEvent
    host = result.get('host')
AttributeError: 'str' object has no attribute 'get'
```

# After

```
2023-02-18 21:40:02,004 [DEBUG] sfp_fsecure_riddler : Error processing JSON response from F-Secure Riddler: Expecting value: line 1 column 1 (char 0)
2023-02-18 21:40:02,005 [ERROR] sfp_fsecure_riddler : Could not login to F-Secure Riddler
```