### PR TITLE
Tests: Run flake8 lint test before pytest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,7 @@
 -r ../requirements.txt
 darglint==1.8.1
 dlint==0.14.0
-flake8==4.0.1
+flake8==5.0.4
 flake8-annotations==2.9.1
 flake8-blind-except==0.2.1
 flake8-bugbear==23.2.13
@@ -12,8 +12,7 @@ flake8-sfs==0.0.4
 flake8-simplify==0.19.3
 pytest==7.2.1
 pytest-cov==4.0.0
-pytest-flake8==1.1.1
 pytest-mock==3.10.0
 pytest-xdist==3.2.0
-pycodestyle==2.8.0
+pycodestyle==2.9.0
 responses==0.22.0

--- a/test/run
+++ b/test/run
@@ -1,8 +1,12 @@
 #!/bin/bash
-# Run unit and integration tests.
+# Run unit and integration tests (excluding module integration tests).
 # These same tests are run on all pull requests automatically.
 #
 # Must be run from SpiderFoot root directory; ie:
 # ./test/run
 
-time python3.9 -m pytest -n auto --flake8 --dist loadfile --ignore=test/integration/modules/ --durations=5 --cov-report html --cov=. .
+echo Running flake8 ...
+time python3 -m flake8 . --count --show-source --statistics || exit
+
+echo Running pytest ...
+time python3 -m pytest -n auto --dist loadfile --ignore=test/integration/modules/ --durations=5 --cov-report html --cov=. .


### PR DESCRIPTION
# Tests: Add Python version 3.10 to GitHub tests workflow

Python 3.10 has been around for a while and is the default Python version on Kali Linux.

Python 3.7 is end of life in about 3 months (June 2023).

https://devguide.python.org/versions/

---

# Tests: Run flake8 lint test before pytest

We already do this (since #1203) for GitHub workflows. It makes sense to also do this locally.

This allows the lint tests to fail first which speeds up the local test workflow in the event of failure.

Invoking `flake8` directly instead of via `pytest` allows us to remove `pytest-flake8` from the test requirements, which allows us to clean up the requirements a bit.

`pytest-flake8` is not compatible with newer versions of `flake8`, so we had to pin `flake8` to an old version.

This PR removes `pytest-flake8` and updates `pycodestyle` to `2.9.0` and `flake8` to `5.0.4`. These are the latest versions which are still compatible with Python 3.7. When we drop support for Python 3.7, these can be updated to `2.10.0` and `6.0.0` respectively.
