### PR TITLE
(fix): explicitly install npm in Dockerfile.full

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -41,7 +41,7 @@ RUN apt remove -y cmdtest \
     && apt-get install yarn -y \
     && yarn install \
     && curl -fsSL https://deb.nodesource.com/setup_17.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get install -y npm \
     && npm install -g retire
 
 # Install Google Chrome the New Way (Not via apt-key)


### PR DESCRIPTION
I got this error when running `docker compose up --build -d` in a Project that builds from the master branches Dockerfile.full:
```
 > [spiderfoot 10/32] RUN apt remove -y cmdtest     && apt remove -y yarn     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -     && echo 'deb https://dl.yarnpkg.com/debian/ stable main' |tee /etc/apt/sources.list.d/yarn.list     && apt-get update     && apt-get install yarn -y     && yarn install     && curl -fsSL https://deb.nodesource.com/setup_17.x | bash -     && apt-get install -y nodejs     && npm install -g retire:
[...]
43.31 Reading package lists...
44.13 Building dependency tree...
44.30 Reading state information...
44.67 nodejs is already the newest version (18.13.0+dfsg1-1).
44.67 nodejs set to manually installed.
44.67 0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
44.67 /bin/sh: 1: npm: not found
```

The build fails during the last command (`npm install -g retire`). Installing `npm` through `apt` solves the problem.