### PR TITLE
fix for issue #1820

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -1368,8 +1368,7 @@ if __name__ == "__main__":
     # Load commands from a file
     if args.e:
         try:
-            with open(args.e, 'r') as f:
-                cin = f.read()
+            cin = open(args.e, 'r')
         except BaseException as e:
             print(f"Unable to open {args.e}: ({e})")
             sys.exit(-1)


### PR DESCRIPTION
quick fix for Issue #1820 

block of code reads the file specified by the -e argument into a string, which is then passed to the SpiderFootCli class as the stdin argument. However, the SpiderFootCli class expects an object with a readline method, not a string.

To fix this issue, I have modified the code to pass the file object itself, rather than a string containing the file's contents. Here's a rough idea of what the corrected code might look like: