### PR TITLE
Fix PATH Environment Variable in Dockerfile causing build error (#1832)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN pip3 install -r "$REQUIREMENTS"
 
 
 
-FROM alpine:3.12.0
+FROM alpine:3.13.0
 WORKDIR /home/spiderfoot
 
 # Place database and logs outside installation directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,9 @@ RUN apk add --no-cache gcc git curl python3 python3-dev py3-pip swig tinyxml-dev
  python3-dev musl-dev openssl-dev libffi-dev libxslt-dev libxml2-dev jpeg-dev \
  openjpeg-dev zlib-dev cargo rust
 RUN python3 -m venv /opt/venv
-ENV PATH="/opt/venv/bin":$PATH
+ENV PATH="/opt/venv/bin:$PATH"
 COPY $REQUIREMENTS requirements.txt ./
+
 RUN ls
 RUN echo "$REQUIREMENTS"
 RUN pip3 install -U pip
@@ -49,7 +50,7 @@ RUN pip3 install -r "$REQUIREMENTS"
 
 
 
-FROM alpine:3.13.0
+FROM alpine:3.12.0
 WORKDIR /home/spiderfoot
 
 # Place database and logs outside installation directory


### PR DESCRIPTION
## Summary
This pull request fixes a syntax error in the Dockerfile related to setting the `PATH` environment variable. The adjustment ensures proper path resolution, enhancing the reliability of Docker container execution.

## Changes
- Corrected the `ENV PATH` setting in the Dockerfile.

## Details
Previously, the `PATH` environment variable was set with a misplaced double quote, which could potentially disrupt the correct path resolution for binaries. This has been rectified to ensure smooth operation of the Docker container. The specific change is as follows:

**From:**
```dockerfile
ENV PATH="/opt/venv/bin:"$PATH
```

**To:**
```dockerfile
ENV PATH="/opt/venv/bin:$PATH"
```

## Impact

This change ensures that the environment variable `PATH` is correctly set, allowing the system to properly locate and execute necessary binaries. This is a crucial fix for the functionality of Docker containers built using this Dockerfile.

## References

Related Issue: Fixes #1832 

## Testing

✔️ Ensure that the Docker container builds successfully.
✔️ Verify that the PATH environment variable is set correctly within the container.
✔️ Test the execution of binaries located in /opt/venv/bin.
