### PR TITLE
Update sfp_dns_for_family.py

### DIFF
--- a/modules/sfp_dns_for_family.py
+++ b/modules/sfp_dns_for_family.py
@@ -108,7 +108,7 @@ class sfp_dns_for_family(SpiderFootPlugin):
 
         for result in res:
             k = str(result)
-            if k != '159.69.10.249':
+            if k != '0.0.0.0':
                 continue
 
             self.debug(f"{eventData} blocked by DNS for Family")


### PR DESCRIPTION
DNS for Family has changed how blocked domains are responded. Previously DNS for Family responded with their own A record: 159.69.10.249 but now they respond with A record: 0.0.0.0 which is consistent with how other DNS servers like Cloudflare Family works