### PR TITLE
Fix LeakIX module: correct API model and docs URL

### DIFF
--- a/modules/sfp_leakix.py
+++ b/modules/sfp_leakix.py
@@ -152,7 +152,9 @@ class sfp_leakix(SpiderFootPlugin):
         self.results[eventData] = True
 
         if self.opts['api_key'] == "":
-            self.debug("You enabled sfp_leakix but did not set an API key, results are limited")
+            self.error("You enabled sfp_leakix but did not set an API key!")
+            self.errorState = True
+            return
         self.debug(f"Received event, {eventName}, from {srcModuleName}")
 
         if eventName in ["IP_ADDRESS", "DOMAIN_NAME"]:

--- a/modules/sfp_leakix.py
+++ b/modules/sfp_leakix.py
@@ -26,9 +26,9 @@ class sfp_leakix(SpiderFootPlugin):
         'categories': ["Leaks, Dumps and Breaches"],
         'dataSource': {
             'website': "https://leakix.net/",
-            'model': "FREE_AUTH_UNLIMITED",
+            'model': "FREE_AUTH_LIMITED",
             'references': [
-                "https://leakix.net/api-documentation"
+                "https://docs.leakix.net/"
             ],
             'apiKeyInstructions': [
                 "Visit https://leakix.net/",
@@ -109,7 +109,6 @@ class sfp_leakix(SpiderFootPlugin):
             self.debug("Host not found")
             return None
 
-        # Future proofing - LeakIX does not implement rate limiting
         if res['code'] == '429':
             self.error("You are being rate-limited by LeakIX")
             self.errorState = True


### PR DESCRIPTION
- Change data source model from `FREE_AUTH_UNLIMITED` to `FREE_AUTH_LIMITED` (LeakIX enforces ~1 req/s rate limiting with 429 responses)
- Remove outdated comment stating LeakIX does not implement rate limiting
- Update documentation URL to https://docs.leakix.net/