### PR TITLE
fix: catch specific netaddr exceptions in correlation.py

### DIFF
--- a/spiderfoot/correlation.py
+++ b/spiderfoot/correlation.py
@@ -632,7 +632,7 @@ class SpiderFootCorrelator:
                             if netaddr.IPAddress(event_data) in netaddr.IPNetwork(r):
                                 self.log.debug(f"found subnet match: {event_data} in {r}")
                                 return True
-                        except Exception:
+                        except (ValueError, netaddr.core.AddrFormatError):
                             pass
 
                 if rule['match_method'] == 'exact' and event_data in reference:


### PR DESCRIPTION
## Summary

Replaces a bare `except Exception:` with `except (ValueError, netaddr.core.AddrFormatError):` in the subnet matching logic within `analysis_match_all_to_first_collection()`.

Bare `except Exception` clauses can silently catch and hide unrelated bugs (e.g., `KeyError`, `TypeError`, `AttributeError`) that should propagate. The `netaddr.IPAddress()` and `netaddr.IPNetwork()` calls only raise `ValueError` or `netaddr.core.AddrFormatError` for invalid IP/network inputs, so those are the only exceptions we need to catch here.

Closes #1988

---

Simple fix — bare excepts can hide real bugs. If anyone's new to Python exception handling, this is a good pattern to learn. Feel free to ask me anything!