### PR TITLE
fix: catch specific phonenumbers exception in helpers.py

### DIFF
--- a/spiderfoot/helpers.py
+++ b/spiderfoot/helpers.py
@@ -758,7 +758,7 @@ class SpiderFootHelpers():
 
         try:
             return phonenumbers.is_valid_number(phonenumbers.parse(phone))
-        except Exception:
+        except phonenumbers.NumberParseException:
             return False
 
     @staticmethod


### PR DESCRIPTION
## Summary

Replaces a bare `except Exception:` with `except phonenumbers.NumberParseException:` in the `validPhoneNumber()` method.

The `phonenumbers.parse()` call only raises `NumberParseException` for invalid phone number inputs. A bare `except Exception` can silently swallow unrelated errors (e.g., `TypeError`, `AttributeError`) that should propagate for debugging. Using the specific exception makes the intent clear and ensures only expected errors are caught.

Closes #1985

---

Small exception handling fix. `NumberParseException` is the only thing `phonenumbers` throws here. If you're learning about Python exceptions, this is a great example — happy to help explain!