### PR TITLE
Add default OptiBot configuration and update pytest dependency

### DIFF
--- a/.optibot
+++ b/.optibot
@@ -1,0 +1,18 @@
+{
+  "reviews": {
+    "auto": true,
+    "exclude": [],
+    "include": [],
+    "autoApprove": false,
+    "codeSuggestions": true,
+    "codeSuggestionsSkipFiles": []
+  },
+  "dependencyBundler": {
+    "enabled": false
+  },
+  "summary": {
+    "auto": true,
+    "level": "basic"
+  },
+  "enableCIFixer": false
+}

--- a/modules/sfp_tool_trufflehog.py
+++ b/modules/sfp_tool_trufflehog.py
@@ -15,6 +15,7 @@ import sys
 import json
 import os
 from subprocess import PIPE, Popen, TimeoutExpired
+from urllib.parse import urlparse
 
 from spiderfoot import SpiderFootPlugin, SpiderFootEvent
 
@@ -93,23 +94,29 @@ class sfp_tool_trufflehog(SpiderFootPlugin):
             return
 
         if eventName == "SOCIAL_MEDIA":
-            if "github.com/" in eventData.lower() or "gitlab.com/" in eventData.lower() or "bitbucket.org/" in eventData.lower():
-                try:
-                    url = eventData.split(": ")[1].replace("<SFURL>", "").replace("</SFURL>", "")
-                except BaseException:
-                    self.debug("Unable to extract repository URL, skipping.")
+            try:
+                extracted = eventData.split(": ")[1].replace("<SFURL>", "").replace("</SFURL>", "")
+                parsed = urlparse(extracted)
+                hostname = parsed.hostname.lower() if parsed.hostname else ""
+                if hostname in ["github.com", "gitlab.com", "bitbucket.org"]:
+                    url = extracted
+                else:
                     return
-            else:
+            except BaseException:
+                self.debug("Unable to extract repository URL, skipping.")
                 return
 
         if eventName == "PUBLIC_CODE_REPO" and self.opts['allrepos']:
-            if "github.com/" in eventData.lower() or "gitlab.com/" in eventData.lower() or "bitbucket.org/" in eventData.lower():
-                try:
-                    url = eventData.split("\n")[1].replace("URL: ", "")
-                except BaseException:
-                    self.debug("Unable to extract repository URL, skipping.")
+            try:
+                extracted = eventData.split("\n")[1].replace("URL: ", "")
+                parsed = urlparse(extracted)
+                hostname = parsed.hostname.lower() if parsed.hostname else ""
+                if hostname in ["github.com", "gitlab.com", "bitbucket.org"]:
+                    url = extracted
+                else:
                     return
-            else:
+            except BaseException:
+                self.debug("Unable to extract repository URL, skipping.")
                 return
 
         if not url:

--- a/modules/sfp_tool_trufflehog.py
+++ b/modules/sfp_tool_trufflehog.py
@@ -97,7 +97,7 @@ class sfp_tool_trufflehog(SpiderFootPlugin):
             try:
                 extracted = eventData.split(": ")[1].replace("<SFURL>", "").replace("</SFURL>", "")
                 parsed = urlparse(extracted)
-                hostname = parsed.hostname.lower() if parsed.hostname else ""
+                hostname = (parsed.hostname or "").lower()
                 if hostname in ["github.com", "gitlab.com", "bitbucket.org"]:
                     url = extracted
                 else:
@@ -110,7 +110,7 @@ class sfp_tool_trufflehog(SpiderFootPlugin):
             try:
                 extracted = eventData.split("\n")[1].replace("URL: ", "")
                 parsed = urlparse(extracted)
-                hostname = parsed.hostname.lower() if parsed.hostname else ""
+                hostname = (parsed.hostname or "").lower()
                 if hostname in ["github.com", "gitlab.com", "bitbucket.org"]:
                     url = extracted
                 else:

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -10,7 +10,7 @@ flake8-quotes==3.3.2
 flake8-return==1.2.0
 flake8-sfs==0.0.4
 flake8-simplify==0.19.3
-pytest==7.2.1
+pytest==9.0.3
 pytest-cov==4.0.0
 pytest-mock==3.10.0
 pytest-xdist==3.2.0


### PR DESCRIPTION
This pull request introduces several improvements, primarily focused on making repository URL extraction more robust in the `sfp_tool_trufflehog` module, as well as updating test dependencies and adding a new configuration file. The changes improve how repository URLs are validated and parsed, ensuring only supported hosts are processed, and modernize the testing environment.

Repository URL extraction and validation improvements:

* Updated `modules/sfp_tool_trufflehog.py` to use `urllib.parse` for extracting and validating repository hostnames, ensuring that only URLs from `github.com`, `gitlab.com`, or `bitbucket.org` are processed for both `SOCIAL_MEDIA` and `PUBLIC_CODE_REPO` events. This replaces previous substring checks with more reliable parsing logic. [[1]](diffhunk://#diff-3cc3460d85dcffb4ed4a173e9cda7c265f75bd3625bdf0dc24096a5778d3caffR18) [[2]](diffhunk://#diff-3cc3460d85dcffb4ed4a173e9cda7c265f75bd3625bdf0dc24096a5778d3caffL96-L113)

Testing and configuration updates:

* Upgraded the `pytest` dependency in `test/requirements.txt` from version 7.2.1 to 9.0.3 to ensure compatibility with newer testing features and fixes.
* Added a new `.optibot` configuration file to enable automated reviews, code suggestions, and basic summaries, while disabling dependency bundling and CI fixer features.