### PR TITLE
Fix aggregate_events leaking non-matching sub-events into buckets

### DIFF
--- a/spiderfoot/correlation.py
+++ b/spiderfoot/correlation.py
@@ -555,7 +555,11 @@ class SpiderFootCorrelator:
             """
             topfield, subfield = field.split(".")
             if field.startswith(topfield + "."):
-                for s in event[topfield]:
+                # Iterate over a snapshot copy: removing from the list being
+                # iterated advances the iterator past the next element, so a
+                # non-matching sub-event right after a removed one is skipped
+                # and wrongly survives in the bucket.
+                for s in event[topfield][:]:
                     if s[subfield] != value:
                         event[topfield].remove(s)
 

--- a/test/unit/spiderfoot/test_spiderfootcorrelator.py
+++ b/test/unit/spiderfoot/test_spiderfootcorrelator.py
@@ -37,6 +37,32 @@ class TestSpiderFootCorrelator(unittest.TestCase):
         with self.assertRaises(ValueError):
             correlator.run_correlations()
 
+    def test_aggregate_events_does_not_leak_non_matching_subevents(self):
+        sfdb = SpiderFootDb(self.default_options, False)
+        correlator = SpiderFootCorrelator(sfdb, {})
+
+        rule = {"id": "r", "field": "child.data"}
+        events = [
+            {
+                "id": "E1",
+                "child": [
+                    {"data": "a"},
+                    {"data": "b"},
+                    {"data": "c"},
+                    {"data": "d"},
+                ],
+            }
+        ]
+        buckets = correlator.aggregate_events(rule, events)
+
+        # Each bucket must keep only the sub-events whose subfield matches the
+        # bucket value. Before the fix, mutating the list while iterating
+        # skipped the element after each removed one, leaking non-matching
+        # children (e.g. bucket "a" wrongly kept ["a", "c"]).
+        for value in ("a", "b", "c", "d"):
+            kept = [child["data"] for child in buckets[value][0]["child"]]
+            self.assertEqual(kept, [value])
+
     def test_build_db_criteria_argument_matchrule_invalid_type_should_raise_TypeError(self):
         sfdb = SpiderFootDb(self.default_options, False)
         correlator = SpiderFootCorrelator(sfdb, {})


### PR DESCRIPTION
## Summary

`SpiderFootCorrelator.aggregate_events` corrupts its result buckets when a
correlation rule's `field` is a sub-field (e.g. `child.data`, `source.data`,
`entity.data`): each bucket retains sub-events that do **not** match the bucket
value, which then skews every downstream analysis that re-extracts sub-fields
(threshold counts, outlier counts, `match_all_to_first_collection`).

## Root cause

`event_strip()` mutates the list it is iterating:

```python
for s in event[topfield]:
    if s[subfield] != value:
        event[topfield].remove(s)
```

Removing the current element shifts the remaining elements down one index while
the iterator still advances, so the element **immediately after** each removed
one is never inspected and survives.

For `field = "child.data"` and one event with children `a, b, c, d`:

| bucket | expected | actual (before fix) |
|---|---|---|
| `a` | `["a"]` | `["a", "c"]` |
| `b` | `["b"]` | `["b", "d"]` |
| `c` | `["c"]` | `["b", "c"]` |
| `d` | `["d"]` | `["b", "d"]` |

(Reproduced against the real `aggregate_events`.)

## Fix

Iterate over a snapshot copy so removal can't skip elements:

```python
for s in event[topfield][:]:
    ...
```

## Testing

```text
$ pytest test/unit/spiderfoot/test_spiderfootcorrelator.py -q
17 passed, 55 subtests passed
```

Adds `test_aggregate_events_does_not_leak_non_matching_subevents`, asserting
each bucket keeps only its matching children. flake8-clean on the changed lines.
