### PR TITLE
fix: use pyreadline3 on Windows for the REPL

### DIFF
--- a/sfcli.py
+++ b/sfcli.py
@@ -39,7 +39,10 @@ COPYRIGHT_INFO = "               by Steve Micallef | @spiderfoot\n"
 try:
     import readline
 except ImportError:
-    import pyreadline as readline
+    try:
+        import pyreadline3 as readline
+    except ImportError:
+        import pyreadline as readline
 
 
 # Colors to make things purty


### PR DESCRIPTION

### Summary

`sfcli.py` (lines 39–42) falls back to `import pyreadline as readline` on
platforms without the `readline` stdlib module (e.g. Windows). `pyreadline`
is unmaintained (last release 2019) and crashes on Python 3.13:

```
AttributeError: module 'collections' has no attribute 'Callable'
    (pyreadline/py3k_compat.py, line 8)
```

`collections.Callable` was removed in Python 3.10; pyreadline's py3k shim
still references it, so the SpiderFoot CLI is broken on Windows + Python 3.13
either way (missing module without pyreadline installed, or this crash with
it installed).

This change prefers `pyreadline3` — the maintained fork with Python 3.10+
support — before falling back to legacy `pyreadline`, keeping old installs
working.

### Verification (Windows 11, Python 3.13.9)

Before:
```
$ python -c "from sfcli import SpiderFootCli"
ModuleNotFoundError: No module named 'pyreadline'          # pyreadline not installed
AttributeError: module 'collections' has no attribute 'Callable'  # with legacy pyreadline
```

After (with pyreadline3 installed):
```
$ python -c "from sfcli import SpiderFootCli; print(SpiderFootCli.version)"
sfcli import OK, version: 4.0.0
$ python -c "import readline; print(readline.get_history_item)"
<built-in method get_history_item of ...>
```

Linux/macOS are unaffected: `readline` is part of the stdlib there, so the
fallback branch is never reached.