### PR TITLE
fix: escape HTML output in scan result views (stored XSS)

### DIFF
--- a/spiderfoot/static/js/spiderfoot.js
+++ b/spiderfoot/static/js/spiderfoot.js
@@ -52,6 +52,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
 var sf = {};
 
+// Escape HTML metacharacters in OSINT-collected data before it is rendered
+// into innerHTML, preventing stored XSS via correlation/event results.
+sf.escapeHtml = function (data) {
+  return String(data).replace(/[&<>"']/g, function (c) {
+    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+  });
+};
+
 sf.replace_sfurltag = function (data) {
   if (data.toLowerCase().indexOf("&lt;sfurl&gt;") >= 0) {
     data = data.replace(

--- a/spiderfoot/templates/scaninfo.tmpl
+++ b/spiderfoot/templates/scaninfo.tmpl
@@ -196,15 +196,15 @@
                                 for (var i = 0; i < data.length; i++) {
                                     table += "<tr>";
                                     if (typeName == null) {
-                                        table += "<td><pre class='table-border-bg-inherit'>" + data[i][8] + "</pre></td>";
+                                        table += "<td><pre class='table-border-bg-inherit'>" + sf.escapeHtml(data[i][8]) + "</pre></td>";
                                     }
                                     table += "<td><pre class='table-border-bg-inherit'>";
-                                    table += sf.replace_sfurltag(data[i][1]);
+                                    table += sf.replace_sfurltag(sf.escapeHtml(data[i][1]));
                                     // for debug
                                     table += "</pre></td><td><pre class='table-border-bg-inherit'>";
-                                    table += sf.replace_sfurltag(data[i][2]);
-                                    table += "</pre></td><td><pre class='table-border-bg-inherit'>" + data[i][3];
-                                    table += "</pre></td><td><pre class='table-border-bg-inherit'>" + data[i][0];
+                                    table += sf.replace_sfurltag(sf.escapeHtml(data[i][2]));
+                                    table += "</pre></td><td><pre class='table-border-bg-inherit'>" + sf.escapeHtml(data[i][3]);
+                                    table += "</pre></td><td><pre class='table-border-bg-inherit'>" + sf.escapeHtml(data[i][0]);
                                     table += "</pre></td>";
                                     table += "</tr>";
                                 }
@@ -433,11 +433,11 @@
                 for (var i = 0; i < data.length; i++) {
                     table += "<tr>";
                     table += "<td><pre class='table-border-bg-inherit'>";
-                    table += sf.replace_sfurltag(data[i][1]);
+                    table += sf.replace_sfurltag(sf.escapeHtml(data[i][1]));
                     table += "</pre></td><td><pre class='table-border-bg-inherit'>";
-                    table += sf.replace_sfurltag(data[i][2]);
-                    table += "</pre></td><td><pre class='table-border-bg-inherit'>" + data[i][3];
-                    table += "</pre></td><td><pre class='table-border-bg-inherit'>" + data[i][0];
+                    table += sf.replace_sfurltag(sf.escapeHtml(data[i][2]));
+                    table += "</pre></td><td><pre class='table-border-bg-inherit'>" + sf.escapeHtml(data[i][3]);
+                    table += "</pre></td><td><pre class='table-border-bg-inherit'>" + sf.escapeHtml(data[i][0]);
                     table += "</pre></td>";
                     table += "</tr>";
                 }
@@ -468,8 +468,8 @@
                 table += "<thead><tr><th>Correlation</th><th>Risk</th><th>Data Elements</th></tr></thead><tbody>";
                 for (var i = 0; i < data.length; i++) {
                     table += "<tr>";
-                    table += "<td><a style='cursor: pointer' onClick='toggleCorrelation(\"" + instanceId + "\",\"" + data[i][0] + "\")'>" + data[i][1] + "</a>&nbsp;&nbsp;";
-                    table += "<i class='glyphicon glyphicon-question-sign' style='color: #ccc' rel='tooltip' data-title=\"" + data[i][5] + "\"></i>";
+                    table += "<td><a style='cursor: pointer' onClick='toggleCorrelation(\"" + instanceId + "\",\"" + data[i][0] + "\")'>" + sf.escapeHtml(data[i][1]) + "</a>&nbsp;&nbsp;";
+                    table += "<i class='glyphicon glyphicon-question-sign' style='color: #ccc' rel='tooltip' data-title=\"" + sf.escapeHtml(data[i][5]) + "\"></i>";
                     table += "</td>";
                     if (data[i][3] == "HIGH") {
                         statusy = "alert-danger";
@@ -483,8 +483,8 @@
                     if (data[i][3] == "INFO") {
                         statusy = "alert-success";
                     }
-                    table += "<td><span class='badge " + statusy + "'>" + data[i][3] + "</span></td>";
-                    table += "<td>" + data[i][7] + "</td>";
+                    table += "<td><span class='badge " + statusy + "'>" + sf.escapeHtml(data[i][3]) + "</span></td>";
+                    table += "<td>" + sf.escapeHtml(data[i][7]) + "</td>";
                     table += "</tr><tr class='hidden' id='corrwell_tr_" + data[i][0] + "'><td colspan=3 id='corrwell_td_" + data[i][0] + "'></td></tr>";
                 }
                 table += "</tbody></table>";
@@ -525,10 +525,10 @@
                                 } else {
                                   table += "<tr>";
                                 }
-                                table += "<td>" + data[i][0] + "</a></td>";
-                                table += "<td>" + data[i][1] + "</td>";
-                                table += "<td>" + data[i][2] + "</td>";
-                                table += "<td>" + data[i][3] + "</td>";
+                                table += "<td>" + sf.escapeHtml(data[i][0]) + "</a></td>";
+                                table += "<td>" + sf.escapeHtml(data[i][1]) + "</td>";
+                                table += "<td>" + sf.escapeHtml(data[i][2]) + "</td>";
+                                table += "<td>" + sf.escapeHtml(data[i][3]) + "</td>";
                                 table += "</tr>";
                             }
                             table += "</tbody></table>";
@@ -560,10 +560,10 @@
                             for (var i = 0; i < data.length; i++) {
                                 table += "<tr><td><a class='link' onClick='";
                                 table += "browseEventData(\"${id}\", \"" + escape(data[i][1]) + "\", \"" + data[i][0] + "\", \"full\");'>";
-                                table += data[i][1] + "</a></td>";
-                                table += "<td>" + data[i][4] + "</td>";
-                                table += "<td>" + data[i][3] + "</td>";
-                                table += "<td>" + data[i][2] + "</td>";
+                                table += sf.escapeHtml(data[i][1]) + "</a></td>";
+                                table += "<td>" + sf.escapeHtml(data[i][4]) + "</td>";
+                                table += "<td>" + sf.escapeHtml(data[i][3]) + "</td>";
+                                table += "<td>" + sf.escapeHtml(data[i][2]) + "</td>";
                             }
                             table += "</tbody></table>"
 
@@ -654,11 +654,11 @@
                                 table += "</td>";
                                 table += "<td><pre class='table-border-bg-inherit'>";
                                 //table += "<a href='${docroot}/entityinfo?id=" + data[i][7] + "'>" + data[i][1] + "</a>";
-                                table += sf.replace_sfurltag(data[i][1]);
+                                table += sf.replace_sfurltag(sf.escapeHtml(data[i][1]));
                                 table += "</pre></td><td><pre class='table-border-bg-inherit'>";
-                                table += sf.replace_sfurltag(data[i][2]);
-                                table += "</pre></td><td><pre class='table-border-bg-inherit'>" + data[i][3];
-                                table += "</pre></td><td><pre class='table-border-bg-inherit'>" + data[i][0];
+                                table += sf.replace_sfurltag(sf.escapeHtml(data[i][2]));
+                                table += "</pre></td><td><pre class='table-border-bg-inherit'>" + sf.escapeHtml(data[i][3]);
+                                table += "</pre></td><td><pre class='table-border-bg-inherit'>" + sf.escapeHtml(data[i][0]);
                                 table += "</pre></td>";
                                 table += "</tr>";
                             }
@@ -719,8 +719,8 @@
                             table += "<thead><tr> <th>Unique Data Element</th><th>Occurrences</th></tr></thead><tbody>";
                             for (var i = 0; i < data.length; i++) {
                                 table += "<tr><td><pre class='table-border-bg-inherit'>";
-                                table += sf.replace_sfurltag(data[i][0]);
-                                table += "</pre></td><td>" + data[i][2] + "</td>";
+                                table += sf.replace_sfurltag(sf.escapeHtml(data[i][0]));
+                                table += "</pre></td><td>" + sf.escapeHtml(data[i][2]) + "</td>";
                                 table += "</tr>";
                             }
                             table += "</tbody></table>"


### PR DESCRIPTION

### Summary

Stored XSS (fix #2012): OSINT-collected data is rendered into `innerHTML`
without escaping across **all** scan result views in `scaninfo.tmpl`:

- `browseEventData()` event table — `data[i][1]`/`data[i][2]` via
  `sf.replace_sfurltag()`, plus `data[i][0]`/`data[i][3]`/`data[i][8]`
- `viewScanLog()` — `data[i][0..3]` (log lines can contain collected data)
- `browseEventList()` — `data[i][1]` as link text
- `browseCorrelations()`/`toggleCorrelation()` — correlation titles,
  tooltips, event data
- unique-view (`browseEventData` unique mode) — `data[i][0]`/`data[i][2]`

`sf.replace_sfurltag()` only converts `<sfurl>` markers; it does not escape
HTML, so `<script>`/`<img onerror=...>` collected from a scanned target
execute in the SpiderFoot web UI context.

### Fix

- Add `sf.escapeHtml()` (escapes `& < > " '`) to
  `spiderfoot/static/js/spiderfoot.js`.
- Wrap every OSINT-data concatenation point in `scaninfo.tmpl` (23 calls)
  with `sf.escapeHtml(...)`; where `sfurl` links are intended, apply escape
  **first**, then `sf.replace_sfurltag(...)` so links still render (the
  escaped `&lt;sfurl&gt;` marker is handled by its existing first branch).
- Intentionally untouched (not OSINT-rendered): numeric id attributes
  (`id='cb_...'`, `corrwell_tr_...`) and the `escape()`-encoded value inside
  the `onClick` string in `browseEventList`.

### Verification

- `node --check spiderfoot/static/js/spiderfoot.js` → OK
- Behavior test running payloads through the exact rendering path:
  `<script>alert(1)</script>`, `"><img src=x onerror=alert(1)>`,
  `';alert(1);//`, `<b>bold</b>`, `normal & "quotes"` → all escaped;
  `<sfurl>https://evil.example/p?a=1&b=2</sfurl>` → still renders as a link
- `grep` audit: no bare `data[i]` concatenation remains in `scaninfo.tmpl`
  (only numeric id/attribute usages)

### Files changed

- `spiderfoot/static/js/spiderfoot.js` (+8: `sf.escapeHtml`)
- `spiderfoot/templates/scaninfo.tmpl` (all OSINT-data render points escaped)

Fixes #2012