### PR TITLE
fix: parameterize SQL queries in the db layer

### DIFF
--- a/spiderfoot/db.py
+++ b/spiderfoot/db.py
@@ -1536,8 +1536,8 @@ class SpiderFootDb:
             tbl_event_types st \
             WHERE c.scan_instance_id = ? AND c.source_event_hash = s.hash AND \
             s.scan_instance_id = c.scan_instance_id AND st.event = s.type AND \
-            t.event = c.type AND c.hash in ('%s')" % "','".join(hashIds)
-        qvars = [instanceId]
+            t.event = c.type AND c.hash in (%s)" % ",".join("?" * len(hashIds))
+        qvars = [instanceId] + hashIds
 
         with self.dbhLock:
             try:
@@ -1585,8 +1585,8 @@ class SpiderFootDb:
             FROM tbl_scan_results c, tbl_scan_results s, tbl_event_types t \
             WHERE c.scan_instance_id = ? AND c.source_event_hash = s.hash AND \
             s.scan_instance_id = c.scan_instance_id AND \
-            t.event = c.type AND s.hash in ('%s')" % "','".join(hashIds)
-        qvars = [instanceId]
+            t.event = c.type AND s.hash in (%s)" % ",".join("?" * len(hashIds))
+        qvars = [instanceId] + hashIds
 
         with self.dbhLock:
             try:


### PR DESCRIPTION

### Summary

`SpiderFootDb.scanElementParents()` and `scanElementChildrenDirect()` build
their `IN (...)` clause by string interpolation:

```python
"... AND c.hash in ('%s')" % "','".join(hashIds)
```

The values are already whitelisted with `hashId.isalnum()`, so there is no
practical injection vector (bandit B608 here is a static false positive), but
parameterized queries are the safer, idiomatic pattern — and they silence the
linter warning.

Change both queries to bind each hash as a `?` parameter:

```python
"... AND c.hash in (%s)" % ",".join("?" * len(hashIds))
qvars = [instanceId] + hashIds
```

Behavior is identical: one placeholder per hash, parameters passed through
the existing `execute(qry, qvars)` path.

### Verification

- `python -m py_compile spiderfoot/db.py` → OK
- Unit tests: `pytest test/unit/spiderfoot/ -k db` → **85 passed, 4 skipped**
  (covers `test_spiderfootdb.py`, incl. scan element parent/child lookups)

### Files changed

- `spiderfoot/db.py` (2 query builders)