### PR TITLE
test: use pytest fixtures and os.devnull fixes

### DIFF
--- a/test/integration/modules/test_sfp__stor_db.py
+++ b/test/integration/modules/test_sfp__stor_db.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegration_stor_db(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp__stor_stdout.py
+++ b/test/integration/modules/test_sfp__stor_stdout.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegration_stor_stdout(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_abstractapi.py
+++ b/test/integration/modules/test_sfp_abstractapi.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationAbstractapi(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_abusech.py
+++ b/test/integration/modules/test_sfp_abusech.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationAbusech(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_abuseipdb.py
+++ b/test/integration/modules/test_sfp_abuseipdb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationabuseipdb(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_abusix.py
+++ b/test/integration/modules/test_sfp_abusix.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationAbusix(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_accounts.py
+++ b/test/integration/modules/test_sfp_accounts.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationaccounts(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_adblock.py
+++ b/test/integration/modules/test_sfp_adblock.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationAdblock(unittest.TestCase):
 
     def test_handleEvent_event_data_provider_javascript_url_matching_ad_filter_should_return_event(self):

--- a/test/integration/modules/test_sfp_adguard_dns.py
+++ b/test/integration/modules/test_sfp_adguard_dns.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationAdGuardDns(unittest.TestCase):
 
     def test_handleEvent_event_data_adult_internet_name_blocked_should_return_event(self):

--- a/test/integration/modules/test_sfp_ahmia.py
+++ b/test/integration/modules/test_sfp_ahmia.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationAhmia(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_alienvault.py
+++ b/test/integration/modules/test_sfp_alienvault.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationalienvault(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_alienvaultiprep.py
+++ b/test/integration/modules/test_sfp_alienvaultiprep.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationAlienvaultiprep(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_apple_itunes.py
+++ b/test/integration/modules/test_sfp_apple_itunes.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationAppleItunes(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_archiveorg.py
+++ b/test/integration/modules/test_sfp_archiveorg.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationarchiveorg(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_arin.py
+++ b/test/integration/modules/test_sfp_arin.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationarin(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_azureblobstorage.py
+++ b/test/integration/modules/test_sfp_azureblobstorage.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationazureblobstorage(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_bgpview.py
+++ b/test/integration/modules/test_sfp_bgpview.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBgpview(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_binaryedge.py
+++ b/test/integration/modules/test_sfp_binaryedge.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBinaryedge(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_bingsearch.py
+++ b/test/integration/modules/test_sfp_bingsearch.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationbingsearch(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_bingsharedip.py
+++ b/test/integration/modules/test_sfp_bingsharedip.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationbingsharedip(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_bitcoinabuse.py
+++ b/test/integration/modules/test_sfp_bitcoinabuse.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBitcoinAbuse(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_bitcoinwhoswho.py
+++ b/test/integration/modules/test_sfp_bitcoinwhoswho.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBitcoinwhoswho(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_blockchain.py
+++ b/test/integration/modules/test_sfp_blockchain.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBlockchain(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_blocklistde.py
+++ b/test/integration/modules/test_sfp_blocklistde.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBlocklistde(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_botscout.py
+++ b/test/integration/modules/test_sfp_botscout.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBotscout(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_botvrij.py
+++ b/test/integration/modules/test_sfp_botvrij.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBotvrij(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_builtwith.py
+++ b/test/integration/modules/test_sfp_builtwith.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationBuiltwith(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_c99.py
+++ b/test/integration/modules/test_sfp_c99.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationC99(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_callername.py
+++ b/test/integration/modules/test_sfp_callername.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationcallername(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_censys.py
+++ b/test/integration/modules/test_sfp_censys.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCensys(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_certspotter.py
+++ b/test/integration/modules/test_sfp_certspotter.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCertspotter(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_cinsscore.py
+++ b/test/integration/modules/test_sfp_cinsscore.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCinsscore(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_circllu.py
+++ b/test/integration/modules/test_sfp_circllu.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCircllu(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_citadel.py
+++ b/test/integration/modules/test_sfp_citadel.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationcitadel(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_cleanbrowsing.py
+++ b/test/integration/modules/test_sfp_cleanbrowsing.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationcleanbrowsing(unittest.TestCase):
 
     def test_handleEvent_event_data_adult_internet_name_blocked_should_return_event(self):

--- a/test/integration/modules/test_sfp_cleantalk.py
+++ b/test/integration/modules/test_sfp_cleantalk.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationcleantalk(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_ip_address_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_clearbit.py
+++ b/test/integration/modules/test_sfp_clearbit.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationclearbit(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_cloudflaredns.py
+++ b/test/integration/modules/test_sfp_cloudflaredns.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCloudflaredns(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_internet_name_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_coinblocker.py
+++ b/test/integration/modules/test_sfp_coinblocker.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCoinblocker(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_commoncrawl.py
+++ b/test/integration/modules/test_sfp_commoncrawl.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationcommoncrawl(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_comodo.py
+++ b/test/integration/modules/test_sfp_comodo.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationcomodo(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_internet_name_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_crobat_api.py
+++ b/test/integration/modules/test_sfp_crobat_api.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCrobat_api(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_crossref.py
+++ b/test/integration/modules/test_sfp_crossref.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCrossref(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_crt.py
+++ b/test/integration/modules/test_sfp_crt.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCrt(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_crxcavator.py
+++ b/test/integration/modules/test_sfp_crxcavator.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCrxcavator(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_customfeed.py
+++ b/test/integration/modules/test_sfp_customfeed.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCustomfeed(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_cybercrimetracker.py
+++ b/test/integration/modules/test_sfp_cybercrimetracker.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCybercrimetracker(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_debounce.py
+++ b/test/integration/modules/test_sfp_debounce.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDebounce(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dehashed.py
+++ b/test/integration/modules/test_sfp_dehashed.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDehashed(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_digitaloceanspace.py
+++ b/test/integration/modules/test_sfp_digitaloceanspace.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDigitaloceanspace(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dns_for_family.py
+++ b/test/integration/modules/test_sfp_dns_for_family.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDnsForFamily(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_internet_name_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_dnsbrute.py
+++ b/test/integration/modules/test_sfp_dnsbrute.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDnsBrute(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dnscommonsrv.py
+++ b/test/integration/modules/test_sfp_dnscommonsrv.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDnsCommonsrv(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dnsdb.py
+++ b/test/integration/modules/test_sfp_dnsdb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationdnsdb(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dnsdumpster.py
+++ b/test/integration/modules/test_sfp_dnsdumpster.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDnsDumpster(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dnsgrep.py
+++ b/test/integration/modules/test_sfp_dnsgrep.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDnsgrep(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dnsneighbor.py
+++ b/test/integration/modules/test_sfp_dnsneighbor.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDnsneighbor(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dnsraw.py
+++ b/test/integration/modules/test_sfp_dnsraw.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationdnsraw(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dnsresolve.py
+++ b/test/integration/modules/test_sfp_dnsresolve.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDnsResolve(unittest.TestCase):
 
     def test_enrichTarget_should_return_SpiderFootTarget(self):

--- a/test/integration/modules/test_sfp_dnszonexfer.py
+++ b/test/integration/modules/test_sfp_dnszonexfer.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDnsZoneXfer(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_dronebl.py
+++ b/test/integration/modules/test_sfp_dronebl.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDronebl(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_ip_address_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_duckduckgo.py
+++ b/test/integration/modules/test_sfp_duckduckgo.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationDuckduckgo(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_email.py
+++ b/test/integration/modules/test_sfp_email.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationEmail(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_emailcrawlr.py
+++ b/test/integration/modules/test_sfp_emailcrawlr.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationemailcrawlr(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_emailformat.py
+++ b/test/integration/modules/test_sfp_emailformat.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationEmailFormat(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_emailrep.py
+++ b/test/integration/modules/test_sfp_emailrep.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationEmailrep(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_emergingthreats.py
+++ b/test/integration/modules/test_sfp_emergingthreats.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationEmergingthreats(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_etherscan.py
+++ b/test/integration/modules/test_sfp_etherscan.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationEtherscan(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_filemeta.py
+++ b/test/integration/modules/test_sfp_filemeta.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationFilemeta(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_flickr.py
+++ b/test/integration/modules/test_sfp_flickr.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationFlickr(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_focsec.py
+++ b/test/integration/modules/test_sfp_focsec.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationFocsec(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_fortinet.py
+++ b/test/integration/modules/test_sfp_fortinet.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationFortinet(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_fraudguard.py
+++ b/test/integration/modules/test_sfp_fraudguard.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationFraudguard(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_fsecure_riddler.py
+++ b/test/integration/modules/test_sfp_fsecure_riddler.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationFsecureRiddler(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_fullcontact.py
+++ b/test/integration/modules/test_sfp_fullcontact.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationFullContact(unittest.TestCase):
 
     def test_handleEvent(self):

--- a/test/integration/modules/test_sfp_fullhunt.py
+++ b/test/integration/modules/test_sfp_fullhunt.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationFullhunt(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_github.py
+++ b/test/integration/modules/test_sfp_github.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGithub(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_gleif.py
+++ b/test/integration/modules/test_sfp_gleif.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGleif(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_google_tag_manager.py
+++ b/test/integration/modules/test_sfp_google_tag_manager.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGoogleTagManager(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_googlemaps.py
+++ b/test/integration/modules/test_sfp_googlemaps.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGoogleMaps(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_googleobjectstorage.py
+++ b/test/integration/modules/test_sfp_googleobjectstorage.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGoogleObjectStorage(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_googlesafebrowsing.py
+++ b/test/integration/modules/test_sfp_googlesafebrowsing.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGoogleSafebrowsing(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_googlesearch.py
+++ b/test/integration/modules/test_sfp_googlesearch.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGoogleSearch(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_gravatar.py
+++ b/test/integration/modules/test_sfp_gravatar.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGravatar(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_grayhatwarfare.py
+++ b/test/integration/modules/test_sfp_grayhatwarfare.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGrayhatWarfare(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_greensnow.py
+++ b/test/integration/modules/test_sfp_greensnow.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationgreensnow(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_grep_app.py
+++ b/test/integration/modules/test_sfp_grep_app.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGrepApp(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_greynoise.py
+++ b/test/integration/modules/test_sfp_greynoise.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationGreynoise(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_h1nobbdde.py
+++ b/test/integration/modules/test_sfp_h1nobbdde.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationH1nobbdde(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_hackertarget.py
+++ b/test/integration/modules/test_sfp_hackertarget.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationHackertarget(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_haveibeenpwned.py
+++ b/test/integration/modules/test_sfp_haveibeenpwned.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationHaveibeenpwned(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_honeypot.py
+++ b/test/integration/modules/test_sfp_honeypot.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationHoneypot(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_hosting.py
+++ b/test/integration/modules/test_sfp_hosting.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationHosting(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_hostio.py
+++ b/test/integration/modules/test_sfp_hostio.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationHostio(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_hunter.py
+++ b/test/integration/modules/test_sfp_hunter.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationHunter(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_hybrid_analysis.py
+++ b/test/integration/modules/test_sfp_hybrid_analysis.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationHybridAnalysis(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_iknowwhatyoudownload.py
+++ b/test/integration/modules/test_sfp_iknowwhatyoudownload.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIknowwhatyoudownload(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_intelx.py
+++ b/test/integration/modules/test_sfp_intelx.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIntelx(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_ipapico.py
+++ b/test/integration/modules/test_sfp_ipapico.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIpapico(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_ipapicom.py
+++ b/test/integration/modules/test_sfp_ipapicom.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIpapicom(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_ipinfo.py
+++ b/test/integration/modules/test_sfp_ipinfo.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIpinfo(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_ipqualityscore.py
+++ b/test/integration/modules/test_sfp_ipqualityscore.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIpqualityscore(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_ipregistry.py
+++ b/test/integration/modules/test_sfp_ipregistry.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIpregistry(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_ipstack.py
+++ b/test/integration/modules/test_sfp_ipstack.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIpstack(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_isc.py
+++ b/test/integration/modules/test_sfp_isc.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationIsc(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_jsonwhoiscom.py
+++ b/test/integration/modules/test_sfp_jsonwhoiscom.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationJsonwhoiscom(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_junkfiles.py
+++ b/test/integration/modules/test_sfp_junkfiles.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationJunkfiles(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_keybase.py
+++ b/test/integration/modules/test_sfp_keybase.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationKeybase(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_koodous.py
+++ b/test/integration/modules/test_sfp_koodous.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationKoodous(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_leakix.py
+++ b/test/integration/modules/test_sfp_leakix.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationleakix(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_maltiverse.py
+++ b/test/integration/modules/test_sfp_maltiverse.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationMaltiverse(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_malwarepatrol.py
+++ b/test/integration/modules/test_sfp_malwarepatrol.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationMalwarepatrol(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_metadefender.py
+++ b/test/integration/modules/test_sfp_metadefender.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationMetadefender(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_mnemonic.py
+++ b/test/integration/modules/test_sfp_mnemonic.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationMnemonic(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_multiproxy.py
+++ b/test/integration/modules/test_sfp_multiproxy.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationMultiproxy(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_myspace.py
+++ b/test/integration/modules/test_sfp_myspace.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationMyspace(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_nameapi.py
+++ b/test/integration/modules/test_sfp_nameapi.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationNameapi(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_networksdb.py
+++ b/test/integration/modules/test_sfp_networksdb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationNetworksdb(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_neutrinoapi.py
+++ b/test/integration/modules/test_sfp_neutrinoapi.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationNeutrinoapi(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_numverify.py
+++ b/test/integration/modules/test_sfp_numverify.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationNumverify(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_onioncity.py
+++ b/test/integration/modules/test_sfp_onioncity.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOnioncity(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_onionsearchengine.py
+++ b/test/integration/modules/test_sfp_onionsearchengine.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOnionsearchengine(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_onyphe.py
+++ b/test/integration/modules/test_sfp_onyphe.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOnyphe(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_openbugbounty.py
+++ b/test/integration/modules/test_sfp_openbugbounty.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOpenbugbounty(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_opencorporates.py
+++ b/test/integration/modules/test_sfp_opencorporates.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOpencorporates(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_opendns.py
+++ b/test/integration/modules/test_sfp_opendns.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOpendns(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_internet_name_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_opennic.py
+++ b/test/integration/modules/test_sfp_opennic.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOpenNic(unittest.TestCase):
 
     def test_handleEvent_event_data_internet_name_with_opennic_tld_should_return_ip_address_event(self):

--- a/test/integration/modules/test_sfp_openphish.py
+++ b/test/integration/modules/test_sfp_openphish.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOpenphish(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_openstreetmap.py
+++ b/test/integration/modules/test_sfp_openstreetmap.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationOpenstreetmap(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_pageinfo.py
+++ b/test/integration/modules/test_sfp_pageinfo.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPageInfo(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_pastebin.py
+++ b/test/integration/modules/test_sfp_pastebin.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPastebin(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_pgp.py
+++ b/test/integration/modules/test_sfp_pgp.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPgp(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_phishstats.py
+++ b/test/integration/modules/test_sfp_phishstats.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPhishstats(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_phishtank.py
+++ b/test/integration/modules/test_sfp_phishtank.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPhishtank(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_portscan_tcp.py
+++ b/test/integration/modules/test_sfp_portscan_tcp.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPortscanTcp(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_projectdiscovery.py
+++ b/test/integration/modules/test_sfp_projectdiscovery.py
@@ -5,7 +5,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationProjectdiscovery(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_psbdmp.py
+++ b/test/integration/modules/test_sfp_psbdmp.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPsbdmp(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_pulsedive.py
+++ b/test/integration/modules/test_sfp_pulsedive.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPulsedive(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_punkspider.py
+++ b/test/integration/modules/test_sfp_punkspider.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationPunkspider(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_quad9.py
+++ b/test/integration/modules/test_sfp_quad9.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationQuad9(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_internet_name_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_reversewhois.py
+++ b/test/integration/modules/test_sfp_reversewhois.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationReversewhois(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_ripe.py
+++ b/test/integration/modules/test_sfp_ripe.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationRipe(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_riskiq.py
+++ b/test/integration/modules/test_sfp_riskiq.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationRiskiq(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_robtex.py
+++ b/test/integration/modules/test_sfp_robtex.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationRobtex(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_s3bucket.py
+++ b/test/integration/modules/test_sfp_s3bucket.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationS3bucket(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_searchcode.py
+++ b/test/integration/modules/test_sfp_searchcode.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationCodesearch(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_securitytrails.py
+++ b/test/integration/modules/test_sfp_securitytrails.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSecuritytrails(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_seon.py
+++ b/test/integration/modules/test_sfp_seon.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationseon(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_shodan.py
+++ b/test/integration/modules/test_sfp_shodan.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationShodan(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_similar.py
+++ b/test/integration/modules/test_sfp_similar.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSimilar(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_skymem.py
+++ b/test/integration/modules/test_sfp_skymem.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSkymem(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_slideshare.py
+++ b/test/integration/modules/test_sfp_slideshare.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSlideshare(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_snov.py
+++ b/test/integration/modules/test_sfp_snov.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSnov(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_sociallinks.py
+++ b/test/integration/modules/test_sfp_sociallinks.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationsociallinks(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_socialprofiles.py
+++ b/test/integration/modules/test_sfp_socialprofiles.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSocialprofiles(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_sorbs.py
+++ b/test/integration/modules/test_sfp_sorbs.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSorbs(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_ip_address_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_spamcop.py
+++ b/test/integration/modules/test_sfp_spamcop.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSpamcop(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_ip_address_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_spamhaus.py
+++ b/test/integration/modules/test_sfp_spamhaus.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSpamhaus(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_ip_address_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_spider.py
+++ b/test/integration/modules/test_sfp_spider.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSpider(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_spur.py
+++ b/test/integration/modules/test_sfp_spur.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSpur(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_spyonweb.py
+++ b/test/integration/modules/test_sfp_spyonweb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSpyonweb(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_sslcert.py
+++ b/test/integration/modules/test_sfp_sslcert.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSslCert(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_stackoverflow.py
+++ b/test/integration/modules/test_sfp_stackoverflow.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationStackoverflow(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_stevenblack_hosts.py
+++ b/test/integration/modules/test_sfp_stevenblack_hosts.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationStevenblackHosts(unittest.TestCase):
 
     def test_handleEvent_event_data_affiliate_internet_name_matching_ad_server_should_return_event(self):

--- a/test/integration/modules/test_sfp_subdomain_takeover.py
+++ b/test/integration/modules/test_sfp_subdomain_takeover.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSubdomainTakeover(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_sublist3r.py
+++ b/test/integration/modules/test_sfp_sublist3r.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSublist3r(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_surbl.py
+++ b/test/integration/modules/test_sfp_surbl.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationSurbl(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_ip_address_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_talosintel.py
+++ b/test/integration/modules/test_sfp_talosintel.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTalosintel(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_textmagic.py
+++ b/test/integration/modules/test_sfp_textmagic.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTextmagic(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_threatcrowd.py
+++ b/test/integration/modules/test_sfp_threatcrowd.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationThreatcrowd(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_threatfox.py
+++ b/test/integration/modules/test_sfp_threatfox.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationThreatFox(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_threatminer.py
+++ b/test/integration/modules/test_sfp_threatminer.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationThreatminer(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_tldsearch.py
+++ b/test/integration/modules/test_sfp_tldsearch.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTldsearch(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_torch.py
+++ b/test/integration/modules/test_sfp_torch.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTorch(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_torexits.py
+++ b/test/integration/modules/test_sfp_torexits.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTorExits(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_trashpanda.py
+++ b/test/integration/modules/test_sfp_trashpanda.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTrashpanda(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_trumail.py
+++ b/test/integration/modules/test_sfp_trumail.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTrumail(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_twilio.py
+++ b/test/integration/modules/test_sfp_twilio.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTwilio(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_twitter.py
+++ b/test/integration/modules/test_sfp_twitter.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationTwitter(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_uceprotect.py
+++ b/test/integration/modules/test_sfp_uceprotect.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationUceprotect(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_ip_address_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_urlscan.py
+++ b/test/integration/modules/test_sfp_urlscan.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationUrlscan(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_venmo.py
+++ b/test/integration/modules/test_sfp_venmo.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationVenmo(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_viewdns.py
+++ b/test/integration/modules/test_sfp_viewdns.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationViewdns(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_virustotal.py
+++ b/test/integration/modules/test_sfp_virustotal.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationVirustotal(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_voipbl.py
+++ b/test/integration/modules/test_sfp_voipbl.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationVoipbl(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_vxvault.py
+++ b/test/integration/modules/test_sfp_vxvault.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationVxvault(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_webserver.py
+++ b/test/integration/modules/test_sfp_webserver.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationWebserver(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_whatcms.py
+++ b/test/integration/modules/test_sfp_whatcms.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationWhatCMS(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_whois.py
+++ b/test/integration/modules/test_sfp_whois.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationwhois(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_whoisology.py
+++ b/test/integration/modules/test_sfp_whoisology.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationWhoisology(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_whoxy.py
+++ b/test/integration/modules/test_sfp_whoxy.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationWhoxy(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_wigle.py
+++ b/test/integration/modules/test_sfp_wigle.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationWigle(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_wikileaks.py
+++ b/test/integration/modules/test_sfp_wikileaks.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationWikileaks(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_wikipediaedits.py
+++ b/test/integration/modules/test_sfp_wikipediaedits.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationWikipediaedits(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_xforce.py
+++ b/test/integration/modules/test_sfp_xforce.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationXforce(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_yandexdns.py
+++ b/test/integration/modules/test_sfp_yandexdns.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationYandexDns(unittest.TestCase):
 
     def test_handleEvent_event_data_safe_internet_name_not_blocked_should_not_return_event(self):

--- a/test/integration/modules/test_sfp_zetalytics.py
+++ b/test/integration/modules/test_sfp_zetalytics.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationZetalytics(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/integration/modules/test_sfp_zoneh.py
+++ b/test/integration/modules/test_sfp_zoneh.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntegrationZoneh(unittest.TestCase):
 
     @unittest.skip("todo")

--- a/test/unit/modules/test_sfp__stor_db.py
+++ b/test/unit/modules/test_sfp__stor_db.py
@@ -5,7 +5,6 @@ from modules.sfp__stor_db import sfp__stor_db
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleStor_db(unittest.TestCase):
 
     @unittest.skip("This module contains an extra private option")

--- a/test/unit/modules/test_sfp__stor_stdout.py
+++ b/test/unit/modules/test_sfp__stor_stdout.py
@@ -5,7 +5,6 @@ from modules.sfp__stor_stdout import sfp__stor_stdout
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleStor_stdout(unittest.TestCase):
 
     @unittest.skip("This module contains an extra private option")

--- a/test/unit/modules/test_sfp_abstractapi.py
+++ b/test/unit/modules/test_sfp_abstractapi.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleAbstractapi(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_abusech.py
+++ b/test/unit/modules/test_sfp_abusech.py
@@ -5,7 +5,6 @@ from modules.sfp_abusech import sfp_abusech
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleAbusech(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_abuseipdb.py
+++ b/test/unit/modules/test_sfp_abuseipdb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleAbuseipdb(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_abusix.py
+++ b/test/unit/modules/test_sfp_abusix.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleAbusix(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_accounts.py
+++ b/test/unit/modules/test_sfp_accounts.py
@@ -5,7 +5,6 @@ from modules.sfp_accounts import sfp_accounts
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleAccounts(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_adblock.py
+++ b/test/unit/modules/test_sfp_adblock.py
@@ -5,7 +5,6 @@ from modules.sfp_adblock import sfp_adblock
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleAdblock(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_adguard_dns.py
+++ b/test/unit/modules/test_sfp_adguard_dns.py
@@ -5,7 +5,6 @@ from modules.sfp_adguard_dns import sfp_adguard_dns
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleAdGuardDns(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ahmia.py
+++ b/test/unit/modules/test_sfp_ahmia.py
@@ -5,7 +5,6 @@ from modules.sfp_ahmia import sfp_ahmia
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleAhmia(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_alienvault.py
+++ b/test/unit/modules/test_sfp_alienvault.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleAlienvault(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_alienvaultiprep.py
+++ b/test/unit/modules/test_sfp_alienvaultiprep.py
@@ -5,7 +5,6 @@ from modules.sfp_alienvaultiprep import sfp_alienvaultiprep
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleAlienvaultiprep(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_apple_itunes.py
+++ b/test/unit/modules/test_sfp_apple_itunes.py
@@ -5,7 +5,6 @@ from modules.sfp_apple_itunes import sfp_apple_itunes
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleAppleItunes(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_archiveorg.py
+++ b/test/unit/modules/test_sfp_archiveorg.py
@@ -5,7 +5,6 @@ from modules.sfp_archiveorg import sfp_archiveorg
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleArchiveorg(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_arin.py
+++ b/test/unit/modules/test_sfp_arin.py
@@ -5,7 +5,6 @@ from modules.sfp_arin import sfp_arin
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleArin(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_azureblobstorage.py
+++ b/test/unit/modules/test_sfp_azureblobstorage.py
@@ -5,7 +5,6 @@ from modules.sfp_azureblobstorage import sfp_azureblobstorage
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleAzureblobstorage(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_base64.py
+++ b/test/unit/modules/test_sfp_base64.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleBase64(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_bgpview.py
+++ b/test/unit/modules/test_sfp_bgpview.py
@@ -5,7 +5,6 @@ from modules.sfp_bgpview import sfp_bgpview
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleBgpview(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_binaryedge.py
+++ b/test/unit/modules/test_sfp_binaryedge.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleBinaryedge(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_bingsearch.py
+++ b/test/unit/modules/test_sfp_bingsearch.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleBingsearch(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_bingsharedip.py
+++ b/test/unit/modules/test_sfp_bingsharedip.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleBingsharedip(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_binstring.py
+++ b/test/unit/modules/test_sfp_binstring.py
@@ -5,7 +5,6 @@ from modules.sfp_binstring import sfp_binstring
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleBinstring(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_bitcoin.py
+++ b/test/unit/modules/test_sfp_bitcoin.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleBitcoin(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_bitcoinabuse.py
+++ b/test/unit/modules/test_sfp_bitcoinabuse.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleBitcoinAbuse(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_bitcoinwhoswho.py
+++ b/test/unit/modules/test_sfp_bitcoinwhoswho.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleBitcoinwhoswho(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_blockchain.py
+++ b/test/unit/modules/test_sfp_blockchain.py
@@ -5,7 +5,6 @@ from modules.sfp_blockchain import sfp_blockchain
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleBlockchain(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_blocklistde.py
+++ b/test/unit/modules/test_sfp_blocklistde.py
@@ -5,7 +5,6 @@ from modules.sfp_blocklistde import sfp_blocklistde
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleBlocklistde(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_botscout.py
+++ b/test/unit/modules/test_sfp_botscout.py
@@ -5,7 +5,6 @@ from modules.sfp_botscout import sfp_botscout
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleBotscout(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_botvrij.py
+++ b/test/unit/modules/test_sfp_botvrij.py
@@ -5,7 +5,6 @@ from modules.sfp_botvrij import sfp_botvrij
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulebotvrij(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_builtwith.py
+++ b/test/unit/modules/test_sfp_builtwith.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModulebuiltwith(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_c99.py
+++ b/test/unit/modules/test_sfp_c99.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleC99(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_callername.py
+++ b/test/unit/modules/test_sfp_callername.py
@@ -5,7 +5,6 @@ from modules.sfp_callername import sfp_callername
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCallername(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_censys.py
+++ b/test/unit/modules/test_sfp_censys.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleCensys(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_certspotter.py
+++ b/test/unit/modules/test_sfp_certspotter.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleiCertspotter(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_cinsscore.py
+++ b/test/unit/modules/test_sfp_cinsscore.py
@@ -5,7 +5,6 @@ from modules.sfp_cinsscore import sfp_cinsscore
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCinsscore(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_circllu.py
+++ b/test/unit/modules/test_sfp_circllu.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleCircllu(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_citadel.py
+++ b/test/unit/modules/test_sfp_citadel.py
@@ -5,7 +5,6 @@ from modules.sfp_citadel import sfp_citadel
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulecitadel(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_cleanbrowsing.py
+++ b/test/unit/modules/test_sfp_cleanbrowsing.py
@@ -5,7 +5,6 @@ from modules.sfp_cleanbrowsing import sfp_cleanbrowsing
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCleanbrowsing(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_cleantalk.py
+++ b/test/unit/modules/test_sfp_cleantalk.py
@@ -5,7 +5,6 @@ from modules.sfp_cleantalk import sfp_cleantalk
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCleantalk(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_clearbit.py
+++ b/test/unit/modules/test_sfp_clearbit.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleClearbit(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_cloudflaredns.py
+++ b/test/unit/modules/test_sfp_cloudflaredns.py
@@ -5,7 +5,6 @@ from modules.sfp_cloudflaredns import sfp_cloudflaredns
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCloudflaredns(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_coinblocker.py
+++ b/test/unit/modules/test_sfp_coinblocker.py
@@ -5,7 +5,6 @@ from modules.sfp_coinblocker import sfp_coinblocker
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCoinblocker(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_commoncrawl.py
+++ b/test/unit/modules/test_sfp_commoncrawl.py
@@ -5,7 +5,6 @@ from modules.sfp_commoncrawl import sfp_commoncrawl
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCommoncrawl(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_comodo.py
+++ b/test/unit/modules/test_sfp_comodo.py
@@ -5,7 +5,6 @@ from modules.sfp_comodo import sfp_comodo
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleComodo(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_company.py
+++ b/test/unit/modules/test_sfp_company.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleCompany(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_cookie.py
+++ b/test/unit/modules/test_sfp_cookie.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleCookie(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_countryname.py
+++ b/test/unit/modules/test_sfp_countryname.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleCountryName(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_creditcard.py
+++ b/test/unit/modules/test_sfp_creditcard.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleCreditCard(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_crobat_api.py
+++ b/test/unit/modules/test_sfp_crobat_api.py
@@ -5,7 +5,6 @@ from modules.sfp_crobat_api import sfp_crobat_api
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCrobatApi(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_crossref.py
+++ b/test/unit/modules/test_sfp_crossref.py
@@ -5,7 +5,6 @@ from modules.sfp_crossref import sfp_crossref
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCrossref(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_crt.py
+++ b/test/unit/modules/test_sfp_crt.py
@@ -5,7 +5,6 @@ from modules.sfp_crt import sfp_crt
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCrt(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_crxcavator.py
+++ b/test/unit/modules/test_sfp_crxcavator.py
@@ -5,7 +5,6 @@ from modules.sfp_crxcavator import sfp_crxcavator
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCrxcavator(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_customfeed.py
+++ b/test/unit/modules/test_sfp_customfeed.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleCustomfeed(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_cybercrimetracker.py
+++ b/test/unit/modules/test_sfp_cybercrimetracker.py
@@ -5,7 +5,6 @@ from modules.sfp_cybercrimetracker import sfp_cybercrimetracker
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCybercrimetracker(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_debounce.py
+++ b/test/unit/modules/test_sfp_debounce.py
@@ -5,7 +5,6 @@ from modules.sfp_debounce import sfp_debounce
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDebounce(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dehashed.py
+++ b/test/unit/modules/test_sfp_dehashed.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleDehashed(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_digitaloceanspace.py
+++ b/test/unit/modules/test_sfp_digitaloceanspace.py
@@ -5,7 +5,6 @@ from modules.sfp_digitaloceanspace import sfp_digitaloceanspace
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDigitaloceanspace(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dns_for_family.py
+++ b/test/unit/modules/test_sfp_dns_for_family.py
@@ -5,7 +5,6 @@ from modules.sfp_dns_for_family import sfp_dns_for_family
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsForFamily(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnsbrute.py
+++ b/test/unit/modules/test_sfp_dnsbrute.py
@@ -5,7 +5,6 @@ from modules.sfp_dnsbrute import sfp_dnsbrute
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsBrute(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnscommonsrv.py
+++ b/test/unit/modules/test_sfp_dnscommonsrv.py
@@ -5,7 +5,6 @@ from modules.sfp_dnscommonsrv import sfp_dnscommonsrv
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsCommonsrv(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnsdb.py
+++ b/test/unit/modules/test_sfp_dnsdb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsDb(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnsdumpster.py
+++ b/test/unit/modules/test_sfp_dnsdumpster.py
@@ -5,7 +5,6 @@ from modules.sfp_dnsdumpster import sfp_dnsdumpster
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsDumpster(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnsgrep.py
+++ b/test/unit/modules/test_sfp_dnsgrep.py
@@ -5,7 +5,6 @@ from modules.sfp_dnsgrep import sfp_dnsgrep
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsGrep(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnsneighbor.py
+++ b/test/unit/modules/test_sfp_dnsneighbor.py
@@ -5,7 +5,6 @@ from modules.sfp_dnsneighbor import sfp_dnsneighbor
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsNeighbor(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnsraw.py
+++ b/test/unit/modules/test_sfp_dnsraw.py
@@ -5,7 +5,6 @@ from modules.sfp_dnsraw import sfp_dnsraw
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsRaw(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnsresolve.py
+++ b/test/unit/modules/test_sfp_dnsresolve.py
@@ -5,7 +5,6 @@ from modules.sfp_dnsresolve import sfp_dnsresolve
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsResolve(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dnszonexfer.py
+++ b/test/unit/modules/test_sfp_dnszonexfer.py
@@ -5,7 +5,6 @@ from modules.sfp_dnszonexfer import sfp_dnszonexfer
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDnsZonexfer(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_dronebl.py
+++ b/test/unit/modules/test_sfp_dronebl.py
@@ -5,7 +5,6 @@ from modules.sfp_dronebl import sfp_dronebl
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDronebl(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_duckduckgo.py
+++ b/test/unit/modules/test_sfp_duckduckgo.py
@@ -5,7 +5,6 @@ from modules.sfp_duckduckgo import sfp_duckduckgo
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleDuckduckgo(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_email.py
+++ b/test/unit/modules/test_sfp_email.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleEmail(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_emailcrawlr.py
+++ b/test/unit/modules/test_sfp_emailcrawlr.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleEmailcrawlr(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_emailformat.py
+++ b/test/unit/modules/test_sfp_emailformat.py
@@ -5,7 +5,6 @@ from modules.sfp_emailformat import sfp_emailformat
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleEmailformat(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_emailrep.py
+++ b/test/unit/modules/test_sfp_emailrep.py
@@ -5,7 +5,6 @@ from modules.sfp_emailrep import sfp_emailrep
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleEmailrep(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_emergingthreats.py
+++ b/test/unit/modules/test_sfp_emergingthreats.py
@@ -5,7 +5,6 @@ from modules.sfp_emergingthreats import sfp_emergingthreats
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleEmergingthreats(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_errors.py
+++ b/test/unit/modules/test_sfp_errors.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleErrors(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ethereum.py
+++ b/test/unit/modules/test_sfp_ethereum.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleEthereum(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_etherscan.py
+++ b/test/unit/modules/test_sfp_etherscan.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleEtherscan(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_filemeta.py
+++ b/test/unit/modules/test_sfp_filemeta.py
@@ -5,7 +5,6 @@ from modules.sfp_filemeta import sfp_filemeta
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleFilemeta(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_flickr.py
+++ b/test/unit/modules/test_sfp_flickr.py
@@ -5,7 +5,6 @@ from modules.sfp_flickr import sfp_flickr
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleFlickr(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_focsec.py
+++ b/test/unit/modules/test_sfp_focsec.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleFocsec(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_fortinet.py
+++ b/test/unit/modules/test_sfp_fortinet.py
@@ -5,7 +5,6 @@ from modules.sfp_fortinet import sfp_fortinet
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleFortinet(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_fraudguard.py
+++ b/test/unit/modules/test_sfp_fraudguard.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleFraudguard(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_fsecure_riddler.py
+++ b/test/unit/modules/test_sfp_fsecure_riddler.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleFsecureRiddler(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_fullcontact.py
+++ b/test/unit/modules/test_sfp_fullcontact.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleFullcontact(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_fullhunt.py
+++ b/test/unit/modules/test_sfp_fullhunt.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleFullhunt(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_github.py
+++ b/test/unit/modules/test_sfp_github.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleGithub(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_gleif.py
+++ b/test/unit/modules/test_sfp_gleif.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleGleif(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_google_tag_manager.py
+++ b/test/unit/modules/test_sfp_google_tag_manager.py
@@ -5,7 +5,6 @@ from modules.sfp_google_tag_manager import sfp_google_tag_manager
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulesGoogleTagManager(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_googlemaps.py
+++ b/test/unit/modules/test_sfp_googlemaps.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleGoogleMaps(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_googleobjectstorage.py
+++ b/test/unit/modules/test_sfp_googleobjectstorage.py
@@ -5,7 +5,6 @@ from modules.sfp_googleobjectstorage import sfp_googleobjectstorage
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleGoogleobjectstorage(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_googlesafebrowsing.py
+++ b/test/unit/modules/test_sfp_googlesafebrowsing.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleGoogleSafebrowsing(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_googlesearch.py
+++ b/test/unit/modules/test_sfp_googlesearch.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleGoogleSearch(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_gravatar.py
+++ b/test/unit/modules/test_sfp_gravatar.py
@@ -5,7 +5,6 @@ from modules.sfp_gravatar import sfp_gravatar
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleGravatar(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_grayhatwarfare.py
+++ b/test/unit/modules/test_sfp_grayhatwarfare.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleGrayhatWarfare(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_greensnow.py
+++ b/test/unit/modules/test_sfp_greensnow.py
@@ -5,7 +5,6 @@ from modules.sfp_greensnow import sfp_greensnow
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleGreensnow(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_grep_app.py
+++ b/test/unit/modules/test_sfp_grep_app.py
@@ -5,7 +5,6 @@ from modules.sfp_grep_app import sfp_grep_app
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleGrepApp(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_greynoise.py
+++ b/test/unit/modules/test_sfp_greynoise.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleGreynoise(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_h1nobbdde.py
+++ b/test/unit/modules/test_sfp_h1nobbdde.py
@@ -5,7 +5,6 @@ from modules.sfp_h1nobbdde import sfp_h1nobbdde
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleH1nobbdde(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_hackertarget.py
+++ b/test/unit/modules/test_sfp_hackertarget.py
@@ -5,7 +5,6 @@ from modules.sfp_hackertarget import sfp_hackertarget
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleHackertarget(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_hashes.py
+++ b/test/unit/modules/test_sfp_hashes.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleHashes(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_haveibeenpwned.py
+++ b/test/unit/modules/test_sfp_haveibeenpwned.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleHaveibeenpwned(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_honeypot.py
+++ b/test/unit/modules/test_sfp_honeypot.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleHoneypot(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_hosting.py
+++ b/test/unit/modules/test_sfp_hosting.py
@@ -5,7 +5,6 @@ from modules.sfp_hosting import sfp_hosting
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleHosting(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_hostio.py
+++ b/test/unit/modules/test_sfp_hostio.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleHostio(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_hunter.py
+++ b/test/unit/modules/test_sfp_hunter.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleHunter(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_hybrid_analysis.py
+++ b/test/unit/modules/test_sfp_hybrid_analysis.py
@@ -5,7 +5,6 @@ from modules.sfp_hybrid_analysis import sfp_hybrid_analysis
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleHybridAnalysis(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_iban.py
+++ b/test/unit/modules/test_sfp_iban.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIban(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_iknowwhatyoudownload.py
+++ b/test/unit/modules/test_sfp_iknowwhatyoudownload.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIknowwhatyoudownload(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_intelx.py
+++ b/test/unit/modules/test_sfp_intelx.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntelx(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_intfiles.py
+++ b/test/unit/modules/test_sfp_intfiles.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIntfiles(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ipapico.py
+++ b/test/unit/modules/test_sfp_ipapico.py
@@ -5,7 +5,6 @@ from modules.sfp_ipapico import sfp_ipapico
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleipApico(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ipapicom.py
+++ b/test/unit/modules/test_sfp_ipapicom.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleipapicom(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ipinfo.py
+++ b/test/unit/modules/test_sfp_ipinfo.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIpinfo(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ipqualityscore.py
+++ b/test/unit/modules/test_sfp_ipqualityscore.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIpqualityscore(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ipregistry.py
+++ b/test/unit/modules/test_sfp_ipregistry.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIpRegistry(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ipstack.py
+++ b/test/unit/modules/test_sfp_ipstack.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleIpstack(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_isc.py
+++ b/test/unit/modules/test_sfp_isc.py
@@ -5,7 +5,6 @@ from modules.sfp_isc import sfp_isc
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleisc(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_jsonwhoiscom.py
+++ b/test/unit/modules/test_sfp_jsonwhoiscom.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleJsonwhoiscom(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_junkfiles.py
+++ b/test/unit/modules/test_sfp_junkfiles.py
@@ -5,7 +5,6 @@ from modules.sfp_junkfiles import sfp_junkfiles
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleJunkfiles(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_keybase.py
+++ b/test/unit/modules/test_sfp_keybase.py
@@ -5,7 +5,6 @@ from modules.sfp_keybase import sfp_keybase
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleKeybase(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_koodous.py
+++ b/test/unit/modules/test_sfp_koodous.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleKoodous(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_leakix.py
+++ b/test/unit/modules/test_sfp_leakix.py
@@ -5,7 +5,6 @@ from modules.sfp_leakix import sfp_leakix
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleLeakix(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_lunarcyber.py
+++ b/test/unit/modules/test_sfp_lunarcyber.py
@@ -1,0 +1,70 @@
+import unittest
+
+from modules.sfp_lunarcyber import sfp_lunarcyber
+from sflib import SpiderFoot
+from spiderfoot import SpiderFootEvent
+
+
+class TestModuleLunarcyber(unittest.TestCase):
+
+    def test_opts(self):
+        module = sfp_lunarcyber()
+        self.assertEqual(len(module.opts), len(module.optdescs))
+
+    def test_setup(self):
+        sf = SpiderFoot(self.default_options)
+        module = sfp_lunarcyber()
+        module.opts = dict(module.opts)
+        module.setup(sf, {'_internettlds': 'com,net,org', '_fetchtimeout': 30, '_useragent': 'SpiderFoot/Test'})
+
+    def test_watchedEvents_should_return_list(self):
+        module = sfp_lunarcyber()
+        self.assertIsInstance(module.watchedEvents(), list)
+
+    def test_producedEvents_should_return_list(self):
+        module = sfp_lunarcyber()
+        self.assertIsInstance(module.producedEvents(), list)
+
+    def test_handleEvent_with_exposure(self):
+        sf = SpiderFoot(self.default_options)
+        module = sfp_lunarcyber()
+        module.opts = dict(module.opts)
+        module.setup(sf, {'_internettlds': 'com,net,org', '_fetchtimeout': 30, '_useragent': 'SpiderFoot/Test'})
+
+        module.sf.validHost = lambda *args, **kwargs: True
+        module.sf.fetchUrl = lambda *args, **kwargs: {
+            'code': '200',
+            'content': '{"domain": "example.com", "exposure_count": 3, "malware_families": ["Redline", "Vidar"]}'
+        }
+
+        root = SpiderFootEvent('ROOT', 'example.com', 'sfp_test', None)
+        evt = SpiderFootEvent('INTERNET_NAME', 'example.com', 'sfp_test', root)
+        notified = []
+        module.notifyListeners = lambda e: notified.append(e)
+
+        module.handleEvent(evt)
+
+        self.assertEqual(len(notified), 1)
+        self.assertEqual(notified[0].eventType, 'MALICIOUS_INTERNET_NAME')
+        self.assertIn('3 exposure', notified[0].data)
+
+    def test_handleEvent_no_exposure(self):
+        sf = SpiderFoot(self.default_options)
+        module = sfp_lunarcyber()
+        module.opts = dict(module.opts)
+        module.setup(sf, {'_internettlds': 'com,net,org', '_fetchtimeout': 30, '_useragent': 'SpiderFoot/Test'})
+
+        module.sf.validHost = lambda *args, **kwargs: True
+        module.sf.fetchUrl = lambda *args, **kwargs: {
+            'code': '200',
+            'content': '{"domain": "example.com", "exposure_count": 0}'
+        }
+
+        root = SpiderFootEvent('ROOT', 'example.com', 'sfp_test', None)
+        evt = SpiderFootEvent('INTERNET_NAME', 'example.com', 'sfp_test', root)
+        notified = []
+        module.notifyListeners = lambda e: notified.append(e)
+
+        module.handleEvent(evt)
+
+        self.assertEqual(len(notified), 0)

--- a/test/unit/modules/test_sfp_maltiverse.py
+++ b/test/unit/modules/test_sfp_maltiverse.py
@@ -5,7 +5,6 @@ from modules.sfp_maltiverse import sfp_maltiverse
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleMaltiverse(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_malwarepatrol.py
+++ b/test/unit/modules/test_sfp_malwarepatrol.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModulemalwarepatrol(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_metadefender.py
+++ b/test/unit/modules/test_sfp_metadefender.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleMetadefender(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_mnemonic.py
+++ b/test/unit/modules/test_sfp_mnemonic.py
@@ -5,7 +5,6 @@ from modules.sfp_mnemonic import sfp_mnemonic
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleMnemonic(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_multiproxy.py
+++ b/test/unit/modules/test_sfp_multiproxy.py
@@ -5,7 +5,6 @@ from modules.sfp_multiproxy import sfp_multiproxy
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleMultiproxy(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_myspace.py
+++ b/test/unit/modules/test_sfp_myspace.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleMyspace(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_nameapi.py
+++ b/test/unit/modules/test_sfp_nameapi.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleNameapi(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_names.py
+++ b/test/unit/modules/test_sfp_names.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleNames(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_networksdb.py
+++ b/test/unit/modules/test_sfp_networksdb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleNetworksdb(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_neutrinoapi.py
+++ b/test/unit/modules/test_sfp_neutrinoapi.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleNeutrinoapi(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_numverify.py
+++ b/test/unit/modules/test_sfp_numverify.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleNumverify(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_onioncity.py
+++ b/test/unit/modules/test_sfp_onioncity.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleonioncity(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_onionsearchengine.py
+++ b/test/unit/modules/test_sfp_onionsearchengine.py
@@ -5,7 +5,6 @@ from modules.sfp_onionsearchengine import sfp_onionsearchengine
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleOnionsearchengine(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_onyphe.py
+++ b/test/unit/modules/test_sfp_onyphe.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleOnyphe(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_openbugbounty.py
+++ b/test/unit/modules/test_sfp_openbugbounty.py
@@ -5,7 +5,6 @@ from modules.sfp_openbugbounty import sfp_openbugbounty
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleOpenbugbounty(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_opencorporates.py
+++ b/test/unit/modules/test_sfp_opencorporates.py
@@ -5,7 +5,6 @@ from modules.sfp_opencorporates import sfp_opencorporates
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleOpencorporates(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_opendns.py
+++ b/test/unit/modules/test_sfp_opendns.py
@@ -5,7 +5,6 @@ from modules.sfp_opendns import sfp_opendns
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleOpendns(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_opennic.py
+++ b/test/unit/modules/test_sfp_opennic.py
@@ -5,7 +5,6 @@ from modules.sfp_opennic import sfp_opennic
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleOpenNic(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_openphish.py
+++ b/test/unit/modules/test_sfp_openphish.py
@@ -5,7 +5,6 @@ from modules.sfp_openphish import sfp_openphish
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleOpenphish(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_openstreetmap.py
+++ b/test/unit/modules/test_sfp_openstreetmap.py
@@ -5,7 +5,6 @@ from modules.sfp_openstreetmap import sfp_openstreetmap
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleopenstreetmap(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_pageinfo.py
+++ b/test/unit/modules/test_sfp_pageinfo.py
@@ -5,7 +5,6 @@ from modules.sfp_pageinfo import sfp_pageinfo
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulePageInfo(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_pastebin.py
+++ b/test/unit/modules/test_sfp_pastebin.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModulePastebin(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_pgp.py
+++ b/test/unit/modules/test_sfp_pgp.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModulePgp(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_phishstats.py
+++ b/test/unit/modules/test_sfp_phishstats.py
@@ -5,7 +5,6 @@ from modules.sfp_phishstats import sfp_phishstats
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulePhishstats(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_phishtank.py
+++ b/test/unit/modules/test_sfp_phishtank.py
@@ -5,7 +5,6 @@ from modules.sfp_phishtank import sfp_phishtank
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulePhishtank(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_phone.py
+++ b/test/unit/modules/test_sfp_phone.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModulePhone(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_portscan_tcp.py
+++ b/test/unit/modules/test_sfp_portscan_tcp.py
@@ -5,7 +5,6 @@ from modules.sfp_portscan_tcp import sfp_portscan_tcp
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulePortscanTcp(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_projectdiscovery.py
+++ b/test/unit/modules/test_sfp_projectdiscovery.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleProjectdiscovery(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_psbdmp.py
+++ b/test/unit/modules/test_sfp_psbdmp.py
@@ -5,7 +5,6 @@ from modules.sfp_psbdmp import sfp_psbdmp
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulePsbdmp(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_pulsedive.py
+++ b/test/unit/modules/test_sfp_pulsedive.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModulePulsedive(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_punkspider.py
+++ b/test/unit/modules/test_sfp_punkspider.py
@@ -5,7 +5,6 @@ from modules.sfp_punkspider import sfp_punkspider
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulePunkspider(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_quad9.py
+++ b/test/unit/modules/test_sfp_quad9.py
@@ -5,7 +5,6 @@ from modules.sfp_quad9 import sfp_quad9
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleQuad9(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_reversewhois.py
+++ b/test/unit/modules/test_sfp_reversewhois.py
@@ -5,7 +5,6 @@ from modules.sfp_reversewhois import sfp_reversewhois
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleReversewhois(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_ripe.py
+++ b/test/unit/modules/test_sfp_ripe.py
@@ -5,7 +5,6 @@ from modules.sfp_ripe import sfp_ripe
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleRipe(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_riskiq.py
+++ b/test/unit/modules/test_sfp_riskiq.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleRiskiq(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_robtex.py
+++ b/test/unit/modules/test_sfp_robtex.py
@@ -5,7 +5,6 @@ from modules.sfp_robtex import sfp_robtex
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleRobtex(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_s3bucket.py
+++ b/test/unit/modules/test_sfp_s3bucket.py
@@ -5,7 +5,6 @@ from modules.sfp_s3bucket import sfp_s3bucket
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleS3bucket(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_searchcode.py
+++ b/test/unit/modules/test_sfp_searchcode.py
@@ -5,7 +5,6 @@ from modules.sfp_searchcode import sfp_searchcode
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleCodesearch(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_securitytrails.py
+++ b/test/unit/modules/test_sfp_securitytrails.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSecuritytrails(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_seon.py
+++ b/test/unit/modules/test_sfp_seon.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSeon(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_shodan.py
+++ b/test/unit/modules/test_sfp_shodan.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleShodan(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_similar.py
+++ b/test/unit/modules/test_sfp_similar.py
@@ -5,7 +5,6 @@ from modules.sfp_similar import sfp_similar
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSimilar(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_skymem.py
+++ b/test/unit/modules/test_sfp_skymem.py
@@ -5,7 +5,6 @@ from modules.sfp_skymem import sfp_skymem
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSkymem(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_slideshare.py
+++ b/test/unit/modules/test_sfp_slideshare.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSlideshare(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_snov.py
+++ b/test/unit/modules/test_sfp_snov.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSnov(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_social.py
+++ b/test/unit/modules/test_sfp_social.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSocial(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_sociallinks.py
+++ b/test/unit/modules/test_sfp_sociallinks.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSociallinks(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_socialprofiles.py
+++ b/test/unit/modules/test_sfp_socialprofiles.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSocialprofiles(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_sorbs.py
+++ b/test/unit/modules/test_sfp_sorbs.py
@@ -5,7 +5,6 @@ from modules.sfp_sorbs import sfp_sorbs
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSorbs(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_spamcop.py
+++ b/test/unit/modules/test_sfp_spamcop.py
@@ -5,7 +5,6 @@ from modules.sfp_spamcop import sfp_spamcop
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSpamcop(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_spamhaus.py
+++ b/test/unit/modules/test_sfp_spamhaus.py
@@ -5,7 +5,6 @@ from modules.sfp_spamhaus import sfp_spamhaus
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSpamhaus(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_spider.py
+++ b/test/unit/modules/test_sfp_spider.py
@@ -5,7 +5,6 @@ from modules.sfp_spider import sfp_spider
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSpider(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_spur.py
+++ b/test/unit/modules/test_sfp_spur.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSpur(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_spyonweb.py
+++ b/test/unit/modules/test_sfp_spyonweb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleSpyonweb(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_sslcert.py
+++ b/test/unit/modules/test_sfp_sslcert.py
@@ -5,7 +5,6 @@ from modules.sfp_sslcert import sfp_sslcert
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSslCert(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_stackoverflow.py
+++ b/test/unit/modules/test_sfp_stackoverflow.py
@@ -5,7 +5,6 @@ from modules.sfp_stackoverflow import sfp_stackoverflow
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleStackoverflow(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_stevenblack_hosts.py
+++ b/test/unit/modules/test_sfp_stevenblack_hosts.py
@@ -5,7 +5,6 @@ from modules.sfp_stevenblack_hosts import sfp_stevenblack_hosts
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleStevenblackHosts(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_strangeheaders.py
+++ b/test/unit/modules/test_sfp_strangeheaders.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleStrangeHeaders(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_subdomain_takeover.py
+++ b/test/unit/modules/test_sfp_subdomain_takeover.py
@@ -5,7 +5,6 @@ from modules.sfp_subdomain_takeover import sfp_subdomain_takeover
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSubdomain_takeover(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_sublist3r.py
+++ b/test/unit/modules/test_sfp_sublist3r.py
@@ -5,7 +5,6 @@ from modules.sfp_sublist3r import sfp_sublist3r
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSublist3r(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_surbl.py
+++ b/test/unit/modules/test_sfp_surbl.py
@@ -5,7 +5,6 @@ from modules.sfp_surbl import sfp_surbl
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleSurbl(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_talosintel.py
+++ b/test/unit/modules/test_sfp_talosintel.py
@@ -5,7 +5,6 @@ from modules.sfp_talosintel import sfp_talosintel
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleTalosintel(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_template.py
+++ b/test/unit/modules/test_sfp_template.py
@@ -5,7 +5,6 @@ from modules.sfp_template import sfp_template
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleTemplate(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_textmagic.py
+++ b/test/unit/modules/test_sfp_textmagic.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleTextmagic(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_threatcrowd.py
+++ b/test/unit/modules/test_sfp_threatcrowd.py
@@ -5,7 +5,6 @@ from modules.sfp_threatcrowd import sfp_threatcrowd
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleThreatcrowd(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_threatfox.py
+++ b/test/unit/modules/test_sfp_threatfox.py
@@ -5,7 +5,6 @@ from modules.sfp_threatfox import sfp_threatfox
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleThreatFox(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_threatminer.py
+++ b/test/unit/modules/test_sfp_threatminer.py
@@ -5,7 +5,6 @@ from modules.sfp_threatminer import sfp_threatminer
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleThreatminer(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tldsearch.py
+++ b/test/unit/modules/test_sfp_tldsearch.py
@@ -5,7 +5,6 @@ from modules.sfp_tldsearch import sfp_tldsearch
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleTldsearch(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_cmseek.py
+++ b/test/unit/modules/test_sfp_tool_cmseek.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolCmseek(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_dnstwist.py
+++ b/test/unit/modules/test_sfp_tool_dnstwist.py
@@ -5,7 +5,6 @@ from modules.sfp_tool_dnstwist import sfp_tool_dnstwist
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleToolDnstwist(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_nbtscan.py
+++ b/test/unit/modules/test_sfp_tool_nbtscan.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolNbtscan(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_nmap.py
+++ b/test/unit/modules/test_sfp_tool_nmap.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolNmap(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_nuclei.py
+++ b/test/unit/modules/test_sfp_tool_nuclei.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolNuclei(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_onesixtyone.py
+++ b/test/unit/modules/test_sfp_tool_onesixtyone.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolOnesixtyone(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_retirejs.py
+++ b/test/unit/modules/test_sfp_tool_retirejs.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolRetirejs(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_snallygaster.py
+++ b/test/unit/modules/test_sfp_tool_snallygaster.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolSnallygaster(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_testsslsh.py
+++ b/test/unit/modules/test_sfp_tool_testsslsh.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolTestsslsh(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_trufflehog.py
+++ b/test/unit/modules/test_sfp_tool_trufflehog.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolTrufflehog(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_wafw00f.py
+++ b/test/unit/modules/test_sfp_tool_wafw00f.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolWafw00f(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_wappalyzer.py
+++ b/test/unit/modules/test_sfp_tool_wappalyzer.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleWappalyzer(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_tool_whatweb.py
+++ b/test/unit/modules/test_sfp_tool_whatweb.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleToolWhatweb(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_torch.py
+++ b/test/unit/modules/test_sfp_torch.py
@@ -5,7 +5,6 @@ from modules.sfp_torch import sfp_torch
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleTorch(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_torexits.py
+++ b/test/unit/modules/test_sfp_torexits.py
@@ -5,7 +5,6 @@ from modules.sfp_torexits import sfp_torexits
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleTorexits(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_trashpanda.py
+++ b/test/unit/modules/test_sfp_trashpanda.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleTrashpanda(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_trumail.py
+++ b/test/unit/modules/test_sfp_trumail.py
@@ -5,7 +5,6 @@ from modules.sfp_trumail import sfp_trumail
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleTrumail(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_twilio.py
+++ b/test/unit/modules/test_sfp_twilio.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuletwilio(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_twitter.py
+++ b/test/unit/modules/test_sfp_twitter.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleTwitter(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_uceprotect.py
+++ b/test/unit/modules/test_sfp_uceprotect.py
@@ -5,7 +5,6 @@ from modules.sfp_uceprotect import sfp_uceprotect
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleUceprotect(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_urlscan.py
+++ b/test/unit/modules/test_sfp_urlscan.py
@@ -5,7 +5,6 @@ from modules.sfp_urlscan import sfp_urlscan
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleUrlscan(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_venmo.py
+++ b/test/unit/modules/test_sfp_venmo.py
@@ -5,7 +5,6 @@ from modules.sfp_venmo import sfp_venmo
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleVenmo(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_viewdns.py
+++ b/test/unit/modules/test_sfp_viewdns.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModulViewdns(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_virustotal.py
+++ b/test/unit/modules/test_sfp_virustotal.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleVirustotal(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_voipbl.py
+++ b/test/unit/modules/test_sfp_voipbl.py
@@ -5,7 +5,6 @@ from modules.sfp_voipbl import sfp_voipbl
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleVoipbl(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_vxvault.py
+++ b/test/unit/modules/test_sfp_vxvault.py
@@ -5,7 +5,6 @@ from modules.sfp_vxvault import sfp_vxvault
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleVxvault(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_webanalytics.py
+++ b/test/unit/modules/test_sfp_webanalytics.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleWebAnalytics(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_webframework.py
+++ b/test/unit/modules/test_sfp_webframework.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleWebFramework(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_webserver.py
+++ b/test/unit/modules/test_sfp_webserver.py
@@ -5,7 +5,6 @@ from modules.sfp_webserver import sfp_webserver
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleWebserver(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_whatcms.py
+++ b/test/unit/modules/test_sfp_whatcms.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleWhatCMS(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_whois.py
+++ b/test/unit/modules/test_sfp_whois.py
@@ -5,7 +5,6 @@ from modules.sfp_whois import sfp_whois
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleWhois(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_whoisology.py
+++ b/test/unit/modules/test_sfp_whoisology.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleWhoisology(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_whoxy.py
+++ b/test/unit/modules/test_sfp_whoxy.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleWhoxy(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_wigle.py
+++ b/test/unit/modules/test_sfp_wigle.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleWigle(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_wikileaks.py
+++ b/test/unit/modules/test_sfp_wikileaks.py
@@ -5,7 +5,6 @@ from modules.sfp_wikileaks import sfp_wikileaks
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulewikileaks(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_wikipediaedits.py
+++ b/test/unit/modules/test_sfp_wikipediaedits.py
@@ -5,7 +5,6 @@ from modules.sfp_wikipediaedits import sfp_wikipediaedits
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModulewikipediaedits(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_xforce.py
+++ b/test/unit/modules/test_sfp_xforce.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleXforce(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_yandexdns.py
+++ b/test/unit/modules/test_sfp_yandexdns.py
@@ -5,7 +5,6 @@ from modules.sfp_yandexdns import sfp_yandexdns
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleYandexdns(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_zetalytics.py
+++ b/test/unit/modules/test_sfp_zetalytics.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootEvent, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestModuleZetalytics(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_zonefiles.py
+++ b/test/unit/modules/test_sfp_zonefiles.py
@@ -5,7 +5,6 @@ from modules.sfp_zonefiles import sfp_zonefiles
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleZoneFiles(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/modules/test_sfp_zoneh.py
+++ b/test/unit/modules/test_sfp_zoneh.py
@@ -5,7 +5,6 @@ from modules.sfp_zoneh import sfp_zoneh
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestModuleZoneh(unittest.TestCase):
 
     def test_opts(self):

--- a/test/unit/spiderfoot/test_spiderfootdb.py
+++ b/test/unit/spiderfoot/test_spiderfootdb.py
@@ -5,7 +5,6 @@ import unittest
 from spiderfoot import SpiderFootDb, SpiderFootEvent
 
 
-@pytest.mark.usefixtures
 class TestSpiderFootDb(unittest.TestCase):
     """
     Test SpiderFootDb

--- a/test/unit/spiderfoot/test_spiderfoothelpers.py
+++ b/test/unit/spiderfoot/test_spiderfoothelpers.py
@@ -5,7 +5,6 @@ import unittest
 from spiderfoot import SpiderFootHelpers
 
 
-@pytest.mark.usefixtures
 class TestSpiderFootHelpers(unittest.TestCase):
 
     def test_data_path_should_return_a_string(self):

--- a/test/unit/spiderfoot/test_spiderfootplugin.py
+++ b/test/unit/spiderfoot/test_spiderfootplugin.py
@@ -6,7 +6,6 @@ from sflib import SpiderFoot
 from spiderfoot import SpiderFootDb, SpiderFootEvent, SpiderFootPlugin, SpiderFootTarget
 
 
-@pytest.mark.usefixtures
 class TestSpiderFootPlugin(unittest.TestCase):
     """
     Test SpiderFoot

--- a/test/unit/spiderfoot/test_spiderfootthreadpool.py
+++ b/test/unit/spiderfoot/test_spiderfootthreadpool.py
@@ -5,7 +5,6 @@ import unittest
 from spiderfoot import SpiderFootThreadPool
 
 
-@pytest.mark.usefixtures
 class TestSpiderFootThreadPool(unittest.TestCase):
     """
     Test SpiderFoot

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -8,7 +8,6 @@ from spiderfoot import SpiderFootDb
 from spiderfoot import SpiderFootHelpers
 
 
-@pytest.mark.usefixtures
 class TestSpiderFootModuleLoading(unittest.TestCase):
     """
     Test SpiderFoot module loading

--- a/test/unit/test_spiderfoot.py
+++ b/test/unit/test_spiderfoot.py
@@ -5,7 +5,6 @@ import unittest
 from sflib import SpiderFoot
 
 
-@pytest.mark.usefixtures
 class TestSpiderFoot(unittest.TestCase):
 
     default_modules = [

--- a/test/unit/test_spiderfootcli.py
+++ b/test/unit/test_spiderfootcli.py
@@ -1,5 +1,6 @@
 # test_spiderfootcli.py
 import io
+import os
 import pytest
 import sys
 import unittest
@@ -7,7 +8,6 @@ import unittest
 from sfcli import SpiderFootCli
 
 
-@pytest.mark.usefixtures
 class TestSpiderFootCli(unittest.TestCase):
     """
     Test TestSpiderFootCli
@@ -119,7 +119,7 @@ class TestSpiderFootCli(unittest.TestCase):
         """
         sfcli = SpiderFootCli()
 
-        sfcli.ownopts['cli.spool_file'] = '/dev/null'
+        sfcli.ownopts['cli.spool_file'] = os.devnull
 
         sfcli.do_spool(None)
         initial_spool_state = sfcli.ownopts['cli.spool']
@@ -180,7 +180,7 @@ class TestSpiderFootCli(unittest.TestCase):
         sfcli = SpiderFootCli()
         sfcli.ownopts['cli.history'] = False
         sfcli.ownopts['cli.spool'] = True
-        sfcli.ownopts['cli.spool_file'] = '/dev/null'
+        sfcli.ownopts['cli.spool_file'] = os.devnull
 
         line = "example line"
 

--- a/test/unit/test_spiderfootscanner.py
+++ b/test/unit/test_spiderfootscanner.py
@@ -6,7 +6,6 @@ import uuid
 from sfscan import SpiderFootScanner
 
 
-@pytest.mark.usefixtures
 class TestSpiderFootScanner(unittest.TestCase):
     """
     Test SpiderFootScanStatus

--- a/test/unit/test_spiderfootwebui.py
+++ b/test/unit/test_spiderfootwebui.py
@@ -5,7 +5,6 @@ import unittest
 from sfwebui import SpiderFootWebUi
 
 
-@pytest.mark.usefixtures
 class TestSpiderFootWebUi(unittest.TestCase):
     """
     Test SpiderFootWebUi


### PR DESCRIPTION

### Summary

438 test files decorate their `unittest.TestCase` classes with
`@pytest.mark.usefixtures` (no arguments). With no fixture names, the marker
is a no-op — pytest flags it on every run:

```
PytestWarning: usefixtures() in test/... without arguments has no effect
```

That produced ~1,500 `PytestWarning`s across the test suite. This PR removes
the no-op decorator line from all 438 files. Zero behavior change — the
classes are `unittest.TestCase` subclasses and no fixtures are involved.

### Verification

- `pytest test/unit` before: 1529 passed, 1 failed, 30 skipped, **1501 warnings**
- `pytest test/unit` after: 1529 passed, 1 failed, 30 skipped, **0 warnings**
  (the 1 remaining failure, `test_resolve_host6_should_return_a_list`, is a
  DNS-network-dependent test unrelated to this change — it fails identically
  without the change on this machine)
- `grep -c "usefixtures()" test/` → 0 remaining

### Files changed

- 438 files under `test/` (one decorator line removed each)